### PR TITLE
docs: harden differentiation and attribution benchmark specs

### DIFF
--- a/docs/benchmarks/output-schema.md
+++ b/docs/benchmarks/output-schema.md
@@ -12,14 +12,26 @@
     "kernel_version": "6.x",
     "node_count": 3
   },
+  "stats": {
+    "sample_size": 0,
+    "runs_count": 0,
+    "confidence_level": 0.95
+  },
   "metrics": {
     "detection_delay_seconds_median": 0.0,
-    "attribution_accuracy": 0.0,
+    "detection_delay_ci95_low": 0.0,
+    "detection_delay_ci95_high": 0.0,
+    "attribution_macro_f1": 0.0,
+    "attribution_macro_f1_ci95_low": 0.0,
+    "attribution_macro_f1_ci95_high": 0.0,
     "false_positive_rate": 0.0,
     "false_negative_rate": 0.0,
+    "abstain_rate": 0.0,
     "burn_rate_prediction_error": 0.0,
     "collector_cpu_overhead_pct": 0.0,
-    "collector_memory_overhead_mb": 0.0
+    "collector_memory_overhead_mb": 0.0,
+    "events_per_second": 0.0,
+    "dropped_events_rate": 0.0
   }
 }
 ```
@@ -34,8 +46,23 @@ Columns:
 - `predicted_fault_domain`
 - `ground_truth_fault_domain`
 - `confidence`
+- `is_abstain`
 - `detection_delay_seconds`
 - `is_correct`
+
+## File: `confusion_matrix.csv`
+Columns:
+- `actual_fault_domain`
+- `predicted_fault_domain`
+- `count`
+
+## File: `class_metrics.csv`
+Columns:
+- `fault_domain`
+- `precision`
+- `recall`
+- `f1`
+- `support`
 
 ## File: `collector_overhead.csv`
 Columns:
@@ -54,7 +81,13 @@ Columns:
   "kernel_config_hash": "string",
   "fault_harness_version": "string",
   "dataset_seed": 0,
+  "benchmark_manifest_sha256": "string",
   "started_at": "RFC3339",
   "finished_at": "RFC3339"
 }
 ```
+
+## Validation Rules
+- Summary metrics must be recomputable from confusion/class metrics and raw incident predictions.
+- CI fields must use the confidence level declared under `stats.confidence_level`.
+- Any missing required artifact invalidates the benchmark run.

--- a/docs/benchmarks/reports/template.md
+++ b/docs/benchmarks/reports/template.md
@@ -4,14 +4,42 @@
 - Run ID:
 - Scenario:
 - Workload Profile:
+- Cluster/Kernel Profile:
 - Commit:
+- Collector Image Digest:
+
+## Experimental Conditions
+- Baseline:
+- Treatment(s):
+- Fault Injection Matrix Covered:
+- Sample Size:
+- Confidence Level:
 
 ## Key Results
-- Detection delay (median):
-- Attribution accuracy:
-- False positives:
-- Collector overhead (CPU/memory):
+- Detection delay median (with CI95):
+- Attribution macro-F1 (with CI95):
+- Per-fault precision/recall/F1:
+- False positive / false negative rates:
+- Abstain rate:
+- Burn-rate prediction error:
+- Collector overhead (CPU/memory/events/drops):
+
+## Failure and Drift Checks
+- Artifact completeness check:
+- Summary vs raw recomputation check:
+- Environment drift from baseline:
+
+## Raw Artifacts
+- `artifacts/events/*.jsonl`
+- `artifacts/metrics/incident_predictions.csv`
+- `artifacts/metrics/confusion_matrix.csv`
+- `artifacts/metrics/class_metrics.csv`
+- `artifacts/metrics/collector_overhead.csv`
+- `artifacts/summary/attribution_summary.json`
+- `artifacts/environment-manifest.yaml`
 
 ## Notes
-- Multi-fault behavior:
+- Multi-fault behavior observations:
+- Known limitations:
+- Failed scenarios and why:
 - Reproduction command:

--- a/docs/research/landscape-sources.md
+++ b/docs/research/landscape-sources.md
@@ -1,6 +1,9 @@
 # Landscape Sources (LLM SLO eBPF Toolkit)
 
-Primary references used for the competitor/adjacent map.
+Claim date: 2026-02-17  
+Last revalidated: 2026-02-17
+
+Primary references used for competitor and adjacent analysis.
 
 ## eBPF and Observability Platforms
 - OpenTelemetry eBPF Instrumentation first release: <https://opentelemetry.io/blog/2025/obi-announcing-first-release/>
@@ -12,10 +15,20 @@ Primary references used for the competitor/adjacent map.
 - Coroot performance impact: <https://docs.coroot.com/installation/performance-impact/>
 - Datadog Universal Service Monitoring: <https://www.datadoghq.com/product/universal-service-monitoring/>
 - Elastic Universal Profiling: <https://www.elastic.co/guide/en/observability/current/universal-profiling.html>
+- Inspektor Gadget docs: <https://inspektor-gadget.io/docs/latest/>
 - Odigos eBPF instrumentation note: <https://docs.odigos.io/instrumentations/golang/ebpf>
 
-## Adjacent LLM Application-Layer Tooling
-- Langfuse OSS repo: <https://github.com/langfuse/langfuse>
+## Matrix Coverage Mapping
+- `OpenTelemetry eBPF Instrumentation (OBI)` -> OBI release notes
+- `Pixie` -> Pixie data sources
+- `Cilium + Hubble` -> Cilium Hubble docs
+- `Tetragon` -> Tetragon docs
+- `Parca` -> Parca docs
+- `Coroot` -> Coroot architecture/performance docs
+- `Datadog Universal Service Monitoring` -> Datadog USM page
+- `Elastic Universal Profiling` -> Elastic Universal Profiling docs
+- `Inspektor Gadget` -> Inspektor Gadget docs
+- `Odigos` -> Odigos eBPF instrumentation docs
 
 ## Citation Guidance
-Feature sets in this area change quickly. Revalidate claims and release notes before each public benchmark publication.
+Feature sets in this area change quickly; revalidate claims and release notes before each publication.

--- a/docs/strategy/differentiation-strategy.md
+++ b/docs/strategy/differentiation-strategy.md
@@ -1,48 +1,71 @@
 # LLM SLO eBPF Toolkit Differentiation Strategy
 
+Claim date: 2026-02-17  
+Last revalidated: 2026-02-17
+
 ## Goal
-Define an honest, technical differentiation stance for a Kubernetes-first toolkit that improves LLM reliability/security operations through eBPF-grounded telemetry.
+Define a technically defensible differentiation stance for a Kubernetes-first toolkit that improves LLM reliability operations through kernel-grounded telemetry and attribution.
 
 ## Scope and Assumptions
-- Primary environment: Kubernetes multi-tenant clusters.
-- Integration posture: OpenTelemetry-compatible outputs.
-- Product boundary: reliability/security diagnostics, not full APM replacement.
+- Primary buyer: SRE, platform engineering, and security teams operating LLM services.
+- Integration posture: OpenTelemetry-compatible downstream exports.
+- Product boundary: incident attribution and SLO diagnostics, not full APM replacement.
 
-## Competitor and Adjacent Landscape (Top 10)
+## Top 10 Competitor and Adjacent Tools
 
 | Tool | What it does well | What it misses for this target |
 |---|---|---|
-| OpenTelemetry eBPF Instrumentation (OBI) | Zero-code protocol telemetry and strong OSS momentum | Generic signals; lacks opinionated LLM SLO semantics |
-| Pixie | Rich K8s troubleshooting from eBPF data | Limited first-class LLM SLI and burn-rate model |
-| Cilium + Hubble | Strong network identity, flow visibility, and policy context | Network-centric view, not full LLM SLO attribution pipeline |
-| Tetragon | Runtime security events and policy enforcement telemetry | Security-event centric, not SLO-centric LLM workload diagnostics |
-| Parca | Low-overhead continuous profiling | Profiling depth, but not request/token SLO decomposition |
-| Coroot | Integrated eBPF observability plus SLO functions | Broad platform scope; LLM-specific semantics are not primary |
-| Datadog USM | Production-grade service discovery and flow mapping | Closed product and less reproducible open benchmark posture |
-| Elastic Universal Profiling | Broad production profiling with eBPF | Profiling-centric, weaker direct LLM transactional SLO framing |
-| Odigos | Fast auto-instrumentation and OTel pipeline | Tracing-first; weaker kernel-level root-cause attribution by default |
-| Langfuse (adjacent) | LLM traces/evals and application-level analytics | Does not provide kernel/network causality for infrastructure SLO failures |
+| OpenTelemetry eBPF Instrumentation (OBI) | Zero-code signal collection and open standards alignment | Generic telemetry semantics; limited opinionated LLM SLO decomposition |
+| Pixie | Fast Kubernetes troubleshooting with rich eBPF-derived data | Not centered on LLM-specific SLI attribution model and fault labeling workflow |
+| Cilium + Hubble | Strong network identity and flow-level visibility | Network-centric lens does not fully explain user-facing LLM SLO burn paths |
+| Tetragon | Runtime security event visibility and policy telemetry | Security-event focus, not LLM latency/error budget attribution pipeline |
+| Parca | Low-overhead continuous profiling | Profiling depth without integrated LLM request/token SLO semantics |
+| Coroot | Integrated eBPF observability platform with SLO capabilities | Broad platform scope; LLM-specific attribution model is not primary objective |
+| Datadog Universal Service Monitoring | Production-grade service topology and traffic visibility | Closed-stack constraints and less transparent reproducible attribution methodology |
+| Elastic Universal Profiling | Mature production profiling with eBPF coverage | Profiling-first posture, weaker direct incident fault-domain attribution for LLM SLOs |
+| Inspektor Gadget | Practical eBPF tooling for Kubernetes runtime diagnostics | Toolkit-level diagnostics, not opinionated LLM SLO attribution and burn-rate model |
+| Odigos (adjacent) | Quick OTel auto-instrumentation and pipeline integration | App/tracing emphasis; weaker kernel-grounded causality in isolation |
 
-## Honest Gap Assessment (What We Must Execute Well)
-- eBPF portability across kernel versions can impact deployment reliability.
-- Attribution claims are easy to overstate; must publish false-positive/false-negative rates.
-- Kernel telemetry volume can be expensive without careful sampling and aggregation.
-- LLM-specific metrics (for example TTFT) require robust parsing for diverse protocols/providers.
+## Source Mapping
+All competitor claims above map to primary references in `/Users/ogulcanaydogan/Desktop/Projects/YaPAY/eBPF + LLM Inference SLO Toolkit/docs/research/landscape-sources.md`.
+
+## Honest Gap Assessment (Execution Risks)
+- Kernel compatibility risk: portability varies by kernel version and distro defaults.
+- Attribution confidence risk: multi-fault incidents can degrade precision.
+- Overhead risk: event volume can become expensive without robust filtering/aggregation.
+- Semantic extraction risk: TTFT/token metrics can vary across provider protocols.
 
 ## Unique Wedge (3 Pillars)
-1. Kernel-grounded LLM SLO telemetry with no-code coverage.
-2. LLM-native SLI model: TTFT, token throughput, retrieval contribution, provider error classes.
-3. Causal bridge: correlate eBPF events, OTel spans, and kube metadata for incident attribution.
+1. Kernel-grounded telemetry with no-code baseline coverage.
+   - Captures network/runtime indicators even when app instrumentation is partial.
+2. LLM-native SLI semantics.
+   - Models TTFT, token throughput collapse, provider error classes, and retrieval contribution.
+3. Causal attribution graph.
+   - Correlates eBPF events with OTel spans and Kubernetes workload identity for incident diagnosis.
 
-## Differentiation by Buyer Role
-- SRE: faster root-cause localization during latency/error budget burn.
-- Platform: standardized SLO telemetry across inconsistent app instrumentation.
-- Security: visibility into provider egress and runtime anomalies that impact reliability posture.
+## Positioning by Buyer
+- SRE: faster and more confident fault-domain localization during SLO burn.
+- Platform: standardized telemetry posture across heterogeneous LLM services.
+- Security: better visibility into runtime egress anomalies affecting reliability posture.
 
-## Positioning Statement
-LLM SLO eBPF Toolkit is a Kubernetes-first reliability observability layer that uses kernel-grounded data to explain why LLM SLOs are burning, even when application instrumentation is incomplete.
+## Publishable Benchmark Angle
+### Theme
+LLM SLO Attribution Accuracy Under Controlled Fault Injection.
 
-## Proof Requirements for Credibility
-- Public fault-injection benchmark runs with raw attribution outputs.
-- Versioned event schemas for interoperability.
-- Transparent overhead measurements (CPU, memory, event rates) under load.
+### Research Question
+Can kernel-grounded telemetry reduce detection delay and improve fault attribution accuracy versus app-instrumentation-only baselines while staying within strict overhead budgets?
+
+### Experimental Design
+- Baseline: app instrumentation only.
+- Treatment A: eBPF toolkit only.
+- Treatment B: combined app instrumentation + eBPF toolkit.
+
+### Publishability Requirements
+- Publish confusion matrix and per-fault precision/recall/F1.
+- Publish abstain/uncertainty rates when attribution confidence is below threshold.
+- Publish raw event/metric/provenance artifacts and reproducible fault manifests.
+
+## Non-Claims
+- No claim that kernel telemetry alone resolves all attribution ambiguity.
+- No claim that the toolkit replaces full observability/APM platforms.
+- No claim of uniform behavior across all kernels without compatibility testing.

--- a/docs/strategy/killer-demo-stories.md
+++ b/docs/strategy/killer-demo-stories.md
@@ -1,62 +1,64 @@
 # LLM SLO eBPF Toolkit Killer Demo Stories
 
-## Demo 1: 5-Minute Install, First SLO Dashboard
+## Demo 1: 5-Minute Install to First LLM SLO Baseline
 ### Setup
-- Deploy DaemonSet collector in a sample Kubernetes cluster.
-- Run synthetic LLM request load against two namespaces.
+- Deploy collector DaemonSet in a sample Kubernetes cluster.
+- Run synthetic LLM traffic in two namespaces.
 
 ### What to show
-- Auto-discovered LLM service map.
-- Baseline RED metrics plus TTFT distribution.
-- Zero-code instrumentation for initial visibility.
+- Service map and baseline SLO dashboard appear without app code changes.
+- TTFT and error-rate time series are visible per namespace.
 
-### Win condition
-- Useful SLO dashboard appears without app code changes.
+### Measurable win condition
+- First usable dashboard in <= 5 minutes from deploy.
+- >= 95% of requests represented in baseline event stream.
 
-## Demo 2: TTFT Spike Autopsy
+## Demo 2: TTFT Spike Root-Cause in Minutes
 ### Setup
-- Inject DNS or egress latency for one workload path.
+- Inject controlled DNS/egress latency fault on one workload path.
 
 ### What to show
-- TTFT SLO burn detected in near real-time.
-- Attribution points to network degradation path.
-- Affected namespaces/services identified.
+- SLO burn alert fires with detection timestamp.
+- Attribution points to network fault domain and affected workloads.
+- Confidence score and evidence chain are visible.
 
-### Win condition
-- Operator can isolate likely root cause in minutes.
+### Measurable win condition
+- Detection delay improves by >= 30% versus app-only baseline.
+- Correct fault-domain attribution in >= 85% of single-fault runs.
 
-## Demo 3: Noisy Neighbor Fairness Incident
+## Demo 3: Noisy Neighbor Throughput Collapse Attribution
 ### Setup
-- Saturate CPU/cgroup for one tenant workload.
+- Apply CPU throttling to one tenant workload under concurrent traffic.
 
 ### What to show
-- Token throughput degradation for neighboring workloads.
-- Burn-rate alert with culprit workload correlation.
-- Resource-level evidence connected to request-level impact.
+- Token throughput degradation in neighboring workload is detected.
+- Attribution links culprit workload/resource pressure to impacted service.
 
-### Win condition
-- Platform team can act on concrete offender attribution.
+### Measurable win condition
+- Culprit workload identified in <= 3 minutes.
+- False-positive culprit attribution <= 10% across repeated runs.
 
-## Demo 4: Provider 429 Storm Separation
+## Demo 4: Provider 429 Storm vs Cluster Bottleneck Separation
 ### Setup
-- Simulate upstream provider throttling errors.
+- Inject upstream provider 429/5xx bursts while cluster remains healthy.
 
 ### What to show
-- Distinguish upstream saturation from in-cluster bottlenecks.
-- Error budget burn segmented by failure class.
-- Suggested mitigation path (backoff/routing/cap adjustments).
+- Incident classification distinguishes upstream provider failure from in-cluster bottlenecks.
+- Burn-rate impact is segmented by fault domain.
 
-### Win condition
-- Incident responders avoid misdiagnosing cluster internals.
+### Measurable win condition
+- Misclassification rate between provider and cluster domains <= 10%.
+- Runbook recommendation points to upstream mitigation path.
 
-## Demo 5: Canary Release SLO Gate
+## Demo 5: Canary SLO Gate with Attribution Evidence
 ### Setup
-- Compare stable vs canary workloads under same test profile.
+- Execute stable vs canary rollout under identical synthetic profile.
+- Introduce controlled canary regression in latency/error profile.
 
 ### What to show
-- Automated regression detection on TTFT/tail latency/error rate.
-- Confidence signal for rollback or promotion.
-- Artifacted report for change-review trail.
+- Gate blocks promotion based on SLO threshold breach.
+- Attribution report identifies dominant fault contributors.
 
-### Win condition
-- Release pipeline blocks reliability regressions with measurable criteria.
+### Measurable win condition
+- 100% regression cases blocked when thresholds are exceeded.
+- Promotion allowed for non-regressed canary runs in >= 95% of trials.

--- a/docs/strategy/why-this-exists-security-sre.md
+++ b/docs/strategy/why-this-exists-security-sre.md
@@ -1,17 +1,24 @@
 # Why LLM SLO eBPF Toolkit Exists (Security and SRE Narrative)
 
-SRE organizations depend on telemetry quality, but the hardest production systems often have the least consistent instrumentation. LLM workloads make this worse: each request can span ingress, application code, retrieval systems, policy layers, and external model providers. When SLOs degrade, teams often get contradictory signals from logs, traces, and vendor dashboards.
+LLM incidents routinely cross boundaries that teams monitor with separate tools: ingress, service runtime, retrieval backends, policy layers, and external model providers. When SLOs degrade, app-level telemetry alone often answers only part of the question. Teams can detect symptoms but still misidentify cause.
 
-LLM SLO eBPF Toolkit exists to provide ground truth from the kernel outward. It does not replace application instrumentation; it makes operations safer when instrumentation is missing, delayed, or incomplete.
+LLM SLO eBPF Toolkit exists to improve incident attribution quality by adding kernel-grounded evidence to the diagnosis path.
 
-By using eBPF-derived signals at protocol and runtime boundaries, the toolkit can provide baseline visibility quickly without per-service code changes. That matters for SRE response time and for security posture, because blind spots directly increase incident duration.
+The operating model is practical: collect low-level runtime/network signals without requiring immediate code instrumentation changes, correlate those signals with OpenTelemetry spans and Kubernetes identity, then produce attribution outputs tied to SLO burn behavior.
 
-The second problem is semantic mismatch. Traditional RED/USE metrics are necessary but insufficient for LLM workloads. Operators need decomposed indicators tied to user experience and model economics: time-to-first-token, provider tail latency, token throughput collapse, retrieval latency contribution, and policy/guardrail overhead.
+For SRE teams, this reduces triage uncertainty. Instead of debating whether a latency spike came from app code, network behavior, retrieval backend, or provider throttling, responders get an explicit fault-domain hypothesis with confidence and supporting events.
 
-Without these LLM-specific slices, teams guess root cause and apply expensive mitigations that may not improve reliability. The toolkit aims to close that loop by correlating kernel-level signals with OTel spans and Kubernetes workload identity.
+For platform teams, this improves standardization across heterogeneous services where instrumentation quality varies. A kernel-grounded baseline reduces dependency on per-team tracing maturity before meaningful SLO diagnostics are possible.
 
-This project is intentionally Kubernetes-first and open benchmark-oriented. Security and platform teams can inspect what is collected, how it is processed, and what overhead it introduces. The benchmark model uses repeatable fault injection so attribution claims are measurable, not anecdotal.
+For security-adjacent operations, it adds visibility into runtime egress and anomalous behavior that may materially affect reliability posture.
 
-There are real constraints: kernel compatibility, event volume management, and attribution uncertainty in multi-fault conditions. The toolkit treats these as first-class engineering concerns and makes uncertainty explicit in reports.
+The project intentionally treats uncertainty as first-class. Attribution quality is reported with confusion matrix, precision/recall, and abstain rates when confidence is low. That avoids over-claiming certainty in multi-fault conditions.
 
-Why this exists now: LLM systems are entering critical production paths faster than reliability instrumentation standards are maturing. Teams need an open, practical toolkit that can produce trustworthy SLO diagnostics and shorten mean time to resolution.
+This is not a claim that kernel data is universally sufficient. The value is in a combined model where kernel signals and app traces improve each other.
+
+## What this does not claim
+- It does not claim perfect attribution in concurrent multi-fault incidents.
+- It does not claim zero overhead across all environments.
+- It does not claim replacement of full APM/observability platforms.
+
+The core claim is narrower and testable: improve detection speed and attribution fidelity for LLM SLO incidents with transparent overhead tradeoffs.


### PR DESCRIPTION
## Summary\n- rewrite differentiation strategy with defensible wedge and source mapping\n- tighten demo stories with measurable SRE outcomes\n- strengthen benchmark spec with CI/F1/abstain and failure criteria\n- align output schemas/report templates to reproducibility requirements\n\n## Scope\nDocs-only changes under strategy/benchmarks/research.\n\n## Notes\nNo runtime API changes.