### PR TITLE
feat: add runtime kit with k8s deploy and fault replay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
           go-version: "1.23"
       - name: Go test
         run: go test ./...
+      - name: Fault replay smoke
+        run: |
+          go run ./cmd/faultreplay --scenario mixed --count 24 --out /tmp/fault_samples.jsonl
+          go run ./cmd/benchgen --out artifacts/benchmarks-ci --scenario mixed_faults --input /tmp/fault_samples.jsonl
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.1.0-alpha.4 - 2026-02-18
+- Added Kubernetes deployment skeleton for collector DaemonSet under `deploy/k8s`.
+- Added `cmd/faultreplay` and `pkg/faultreplay` for multi-domain synthetic replay streams (`provider_throttle`, `dns_latency`, `cpu_throttle`, `mixed`).
+- Extended benchmark harness to emit `report.md` as part of each artifact bundle.
+- Added CI smoke path for replay generation + benchmark bundle creation.
+
 ## v0.1.0-alpha.3 - 2026-02-17
 - Added mixed-fault benchmark scenario (`mixed_faults`) combining `provider_throttle` and `dns_latency` labels.
 - Added fixture-driven benchmark input flow using `pkg/benchmark/testdata/mixed_fault_samples.jsonl`.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint bench
+.PHONY: build test lint bench replay
 
 build:
 	go build ./...
@@ -11,3 +11,7 @@ lint:
 
 bench:
 	go run ./cmd/benchgen --out artifacts/benchmarks
+
+replay:
+	go run ./cmd/faultreplay --scenario mixed --count 30 --out artifacts/fault-replay/fault_samples.jsonl
+	go run ./cmd/benchgen --out artifacts/benchmarks-replay --scenario mixed_faults --input artifacts/fault-replay/fault_samples.jsonl

--- a/README.md
+++ b/README.md
@@ -25,6 +25,19 @@ go run ./cmd/benchgen --out artifacts/benchmarks-mixed --scenario mixed_faults
 ```bash
 go run ./cmd/benchgen --out artifacts/benchmarks-input --input pkg/benchmark/testdata/mixed_fault_samples.jsonl
 ```
+8. Generate replay samples for multi-domain faults:
+```bash
+go run ./cmd/faultreplay --scenario mixed --count 30 --out artifacts/fault-replay/fault_samples.jsonl
+```
+9. Build benchmark/report bundle from replay samples:
+```bash
+go run ./cmd/benchgen --out artifacts/benchmarks-replay --scenario mixed_faults --input artifacts/fault-replay/fault_samples.jsonl
+```
+
+## Kubernetes Deployment Skeleton
+```bash
+kubectl apply -k deploy/k8s
+```
 
 ## Differentiation Artifacts
 - `docs/strategy/differentiation-strategy.md`

--- a/cmd/faultreplay/main.go
+++ b/cmd/faultreplay/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ogulcanaydogan/llm-slo-ebpf-toolkit/pkg/faultreplay"
+)
+
+func main() {
+	scenario := flag.String("scenario", "mixed", "fault scenario")
+	count := flag.Int("count", 30, "number of samples to emit")
+	out := flag.String("out", "artifacts/fault-replay/fault_samples.jsonl", "output JSONL path")
+	flag.Parse()
+
+	samples, err := faultreplay.GenerateFaultSamples(*scenario, *count, time.Now().UTC())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to generate replay samples: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(*out), 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "create output directory failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	file, err := os.Create(*out)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "create output file failed: %v\n", err)
+		os.Exit(1)
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	for _, sample := range samples {
+		if err := encoder.Encode(sample); err != nil {
+			fmt.Fprintf(os.Stderr, "encode sample failed: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	fmt.Printf("wrote %d replay samples to %s\n", len(samples), *out)
+}

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,18 @@
+# Kubernetes Collector Deployment
+
+Apply collector manifests:
+
+```bash
+kubectl apply -k deploy/k8s
+```
+
+Delete collector manifests:
+
+```bash
+kubectl delete -k deploy/k8s
+```
+
+Notes:
+- The DaemonSet uses a privileged security context for eBPF access.
+- Update the container image in `deploy/k8s/daemonset.yaml` for your release.
+- Manifests are intended as a baseline and should be adapted to your cluster hardening policy.

--- a/deploy/k8s/clusterrole.yaml
+++ b/deploy/k8s/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: llm-slo-collector
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "pods", "namespaces"]
+    verbs: ["get", "list", "watch"]

--- a/deploy/k8s/clusterrolebinding.yaml
+++ b/deploy/k8s/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: llm-slo-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: llm-slo-collector
+subjects:
+  - kind: ServiceAccount
+    name: llm-slo-collector
+    namespace: llm-slo-system

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: llm-slo-collector-config
+  namespace: llm-slo-system
+data:
+  collector-flags: |
+    --mode daemonset
+    --output jsonl

--- a/deploy/k8s/daemonset.yaml
+++ b/deploy/k8s/daemonset.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: llm-slo-collector
+  namespace: llm-slo-system
+spec:
+  selector:
+    matchLabels:
+      app: llm-slo-collector
+  template:
+    metadata:
+      labels:
+        app: llm-slo-collector
+    spec:
+      serviceAccountName: llm-slo-collector
+      hostPID: true
+      hostNetwork: true
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: collector
+          image: ghcr.io/ogulcanaydogan/llm-slo-ebpf-toolkit-collector:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["BPF", "SYS_ADMIN", "SYS_RESOURCE", "NET_ADMIN"]
+          args:
+            - "--k8s-node=$(NODE_NAME)"
+            - "--output=stdout"
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: sys
+              mountPath: /sys
+              readOnly: true
+            - name: modules
+              mountPath: /lib/modules
+              readOnly: true
+            - name: bpf
+              mountPath: /sys/fs/bpf
+      volumes:
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: modules
+          hostPath:
+            path: /lib/modules
+        - name: bpf
+          hostPath:
+            path: /sys/fs/bpf

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - clusterrole.yaml
+  - clusterrolebinding.yaml
+  - configmap.yaml
+  - daemonset.yaml

--- a/deploy/k8s/namespace.yaml
+++ b/deploy/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: llm-slo-system

--- a/deploy/k8s/serviceaccount.yaml
+++ b/deploy/k8s/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: llm-slo-collector
+  namespace: llm-slo-system

--- a/docs/benchmarks/output-schema.md
+++ b/docs/benchmarks/output-schema.md
@@ -87,6 +87,12 @@ Columns:
 }
 ```
 
+## File: `report.md`
+Required sections:
+- run metadata (`run_id`, scenario, workload)
+- core metrics (accuracy, detection delay, false positive/negative, overhead)
+- artifact bundle list for traceability
+
 ## Validation Rules
 - Summary metrics must be recomputable from confusion/class metrics and raw incident predictions.
 - CI fields must use the confidence level declared under `stats.confidence_level`.

--- a/docs/benchmarks/reports/weekly-2026-02-17.md
+++ b/docs/benchmarks/reports/weekly-2026-02-17.md
@@ -1,32 +1,31 @@
-# Weekly Benchmark and Quality Report (2026-02-17)
+# Weekly Benchmark and Quality Report (2026-02-18)
 
 ## Scope
 - Collector + attribution baseline.
-- Mixed-fault benchmark scenario support and explicit JSONL input mode.
+- Added runtime-oriented delivery kit: Kubernetes DaemonSet skeleton, multi-domain fault replay runner, and report bundle output.
 
 ## Test Summary
 - `go test ./...`: pass
+- `go run ./cmd/faultreplay --scenario mixed --count 24 --out /tmp/fault_samples.jsonl`: pass
+- `go run ./cmd/benchgen --out artifacts/benchmarks-ci --scenario mixed_faults --input /tmp/fault_samples.jsonl`: pass
 - `go run ./cmd/collector`: pass (schema-valid JSONL output)
 - `go run ./cmd/attributor --out <file> --summary-out <file> --confusion-out <file>`: pass
-- `go run ./cmd/benchgen --scenario mixed_faults`: pass
-- `go run ./cmd/benchgen --input pkg/benchmark/testdata/mixed_fault_samples.jsonl`: pass
 
-## Benchmark Snapshot
-- Scenarios: `provider_throttle`, `mixed_faults`
-- Workload profile: `rag_mixed`
-- Output path: `artifacts/benchmarks`
-- Generated artifacts:
-  - `attribution_summary.json`
-  - `confusion-matrix.csv`
-  - `incident_predictions.csv`
-  - `collector_overhead.csv`
-  - `provenance.json`
+## Benchmark Bundle
+- `incident_predictions.csv`
+- `confusion-matrix.csv`
+- `collector_overhead.csv`
+- `attribution_summary.json`
+- `provenance.json`
+- `report.md`
 
-## Benchmark Delta
-- Prior week: single-fault synthetic scenario baseline.
-- Current week: added mixed-domain confusion matrix coverage (`network_dns` + `provider_throttle`) and fixture-driven input replay.
+## Deployment Snapshot
+- Added `deploy/k8s` manifests:
+  - namespace, service account, RBAC, ConfigMap, DaemonSet, kustomization
+- Baseline command:
+  - `kubectl apply -k deploy/k8s`
 
 ## Known Limitations
-- Current collector pipeline uses synthetic input stream; kernel event ingestion is not yet implemented.
-- Attribution is rule-based and tuned for single-fault and low-cardinality mixed-fault cases.
-- `golangci-lint` remains CI-only in this local environment.
+- Collector container image is a placeholder until release pipeline publishes runtime images.
+- Fault replay is synthetic and deterministic; live fault injector integration remains pending.
+- Attribution remains rule-based and is tuned for low-cardinality scenarios.

--- a/pkg/benchmark/harness.go
+++ b/pkg/benchmark/harness.go
@@ -95,6 +95,9 @@ func GenerateArtifactsWithInput(
 	if err := writeJSON(filepath.Join(outDir, "attribution_summary.json"), summary); err != nil {
 		return err
 	}
+	if err := writeReportMarkdown(filepath.Join(outDir, "report.md"), summary); err != nil {
+		return err
+	}
 
 	finishedAt := time.Now().UTC()
 	provenance := map[string]interface{}{
@@ -347,6 +350,42 @@ func writeJSON(path string, payload interface{}) error {
 	}
 	if err := os.WriteFile(path, bytes, 0o644); err != nil {
 		return fmt.Errorf("write json file: %w", err)
+	}
+	return nil
+}
+
+func writeReportMarkdown(path string, summary benchmarkSummary) error {
+	content := fmt.Sprintf(
+		"# Attribution Benchmark Report\n\n"+
+			"- Run ID: `%s`\n"+
+			"- Scenario: `%s`\n"+
+			"- Workload: `%s`\n"+
+			"- Attribution accuracy: `%.4f`\n"+
+			"- Detection delay median (s): `%.2f`\n"+
+			"- False positive rate: `%.4f`\n"+
+			"- False negative rate: `%.4f`\n"+
+			"- Burn-rate prediction error: `%.4f`\n"+
+			"- Collector CPU overhead (%%): `%.2f`\n"+
+			"- Collector memory overhead (MB): `%.2f`\n\n"+
+			"## Bundle\n\n"+
+			"- `incident_predictions.csv`\n"+
+			"- `confusion-matrix.csv`\n"+
+			"- `collector_overhead.csv`\n"+
+			"- `attribution_summary.json`\n"+
+			"- `provenance.json`\n",
+		summary.RunID,
+		summary.Scenario,
+		summary.WorkloadProfile,
+		summary.Metrics.AttributionAccuracy,
+		summary.Metrics.DetectionDelayMedianSeconds,
+		summary.Metrics.FalsePositiveRate,
+		summary.Metrics.FalseNegativeRate,
+		summary.Metrics.BurnRatePredictionError,
+		summary.Metrics.CollectorCPUOverheadPct,
+		summary.Metrics.CollectorMemoryOverheadMB,
+	)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("write report markdown: %w", err)
 	}
 	return nil
 }

--- a/pkg/benchmark/harness_test.go
+++ b/pkg/benchmark/harness_test.go
@@ -20,6 +20,7 @@ func TestGenerateArtifacts(t *testing.T) {
 		"incident_predictions.csv",
 		"collector_overhead.csv",
 		"provenance.json",
+		"report.md",
 	}
 	for _, name := range required {
 		if _, err := os.Stat(filepath.Join(tmp, name)); err != nil {

--- a/pkg/faultreplay/generator.go
+++ b/pkg/faultreplay/generator.go
@@ -1,0 +1,57 @@
+package faultreplay
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ogulcanaydogan/llm-slo-ebpf-toolkit/pkg/attribution"
+)
+
+var scenarioFaultLabels = map[string][]string{
+	"provider_throttle": {"provider_throttle"},
+	"dns_latency":       {"dns_latency"},
+	"cpu_throttle":      {"cpu_throttle"},
+	"mixed":             {"provider_throttle", "dns_latency", "cpu_throttle"},
+}
+
+// GenerateFaultSamples creates deterministic synthetic fault samples for replay.
+func GenerateFaultSamples(
+	scenario string,
+	count int,
+	start time.Time,
+) ([]attribution.FaultSample, error) {
+	labels, ok := scenarioFaultLabels[scenario]
+	if !ok {
+		return nil, fmt.Errorf("unsupported scenario %q", scenario)
+	}
+	if count < 1 {
+		return nil, fmt.Errorf("count must be >= 1")
+	}
+
+	samples := make([]attribution.FaultSample, 0, count)
+	for idx := 0; idx < count; idx++ {
+		label := labels[idx%len(labels)]
+		timestamp := start.Add(time.Duration(idx) * time.Second)
+		samples = append(samples, attribution.FaultSample{
+			IncidentID:     fmt.Sprintf("replay-inc-%04d", idx+1),
+			Timestamp:      timestamp,
+			Cluster:        "local",
+			Namespace:      "default",
+			Service:        "chat",
+			FaultLabel:     label,
+			ExpectedDomain: attribution.MapFaultLabel(label),
+			Confidence:     0.9,
+			BurnRate:       2.0,
+			WindowMinutes:  5,
+			RequestID:      fmt.Sprintf("replay-req-%04d", idx+1),
+			TraceID:        fmt.Sprintf("replay-trace-%04d", idx+1),
+		})
+	}
+
+	return samples, nil
+}
+
+// SupportedScenarios lists accepted replay scenario names.
+func SupportedScenarios() []string {
+	return []string{"provider_throttle", "dns_latency", "cpu_throttle", "mixed"}
+}

--- a/pkg/faultreplay/generator_test.go
+++ b/pkg/faultreplay/generator_test.go
@@ -1,0 +1,31 @@
+package faultreplay
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGenerateFaultSamplesMixed(t *testing.T) {
+	samples, err := GenerateFaultSamples("mixed", 6, time.Unix(0, 0).UTC())
+	if err != nil {
+		t.Fatalf("generate samples: %v", err)
+	}
+	if len(samples) != 6 {
+		t.Fatalf("expected 6 samples, got %d", len(samples))
+	}
+
+	labels := []string{
+		samples[0].FaultLabel,
+		samples[1].FaultLabel,
+		samples[2].FaultLabel,
+	}
+	if labels[0] != "provider_throttle" || labels[1] != "dns_latency" || labels[2] != "cpu_throttle" {
+		t.Fatalf("unexpected label order: %v", labels)
+	}
+}
+
+func TestGenerateFaultSamplesRejectsUnsupportedScenario(t *testing.T) {
+	if _, err := GenerateFaultSamples("unknown", 4, time.Now().UTC()); err == nil {
+		t.Fatal("expected unsupported scenario error")
+	}
+}


### PR DESCRIPTION
## Summary
- add Kubernetes deployment skeleton for collector DaemonSet under `deploy/k8s`
- add `cmd/faultreplay` and `pkg/faultreplay` for multi-domain replay streams (`provider_throttle`, `dns_latency`, `cpu_throttle`, `mixed`)
- extend benchmark harness to emit `report.md` in the artifact bundle
- add CI smoke steps for replay generation and benchmark bundle creation
- refresh docs/changelog for runtime deployment + replay workflow

## Validation
- `go test ./...`
- `go run ./cmd/faultreplay --scenario mixed --count 12 --out <tmp>/fault_samples.jsonl`
- `go run ./cmd/benchgen --out <tmp>/bench --scenario mixed_faults --input <tmp>/fault_samples.jsonl`
