### PR TITLE
feat: collector stream mode, fault injection harness, and baseline reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
           go-version: "1.23"
       - name: Go test
         run: go test ./...
+      - name: Collector fault-injection smoke
+        run: |
+          go run ./cmd/faultinject --scenario mixed --count 16 --out /tmp/faultinject_raw.jsonl
+          go run ./cmd/collector --input /tmp/faultinject_raw.jsonl --output jsonl --output-path /tmp/slo_events.jsonl
       - name: Fault replay smoke
         run: |
           go run ./cmd/faultreplay --scenario mixed --count 24 --out /tmp/fault_samples.jsonl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 ## v0.1.0-alpha.4 - 2026-02-18
 - Added Kubernetes deployment skeleton for collector DaemonSet under `deploy/k8s`.
 - Added `cmd/faultreplay` and `pkg/faultreplay` for multi-domain synthetic replay streams (`provider_throttle`, `dns_latency`, `cpu_throttle`, `mixed`).
+- Added collector runtime flags for input/output mode, synthetic scenario generation, and stream mode (`--count=0`).
+- Added `cmd/faultinject` harness to generate raw collector input streams for controlled fault scenarios.
+- Added synthetic sample metadata enrichment (`node`, `fault_label`) in emitted SLO events.
 - Extended benchmark harness to emit `report.md` as part of each artifact bundle.
-- Added CI smoke path for replay generation + benchmark bundle creation.
+- Added CI smoke path for fault injection -> collector normalization and replay -> benchmark bundle creation.
 
 ## v0.1.0-alpha.3 - 2026-02-17
 - Added mixed-fault benchmark scenario (`mixed_faults`) combining `provider_throttle` and `dns_latency` labels.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint bench replay
+.PHONY: build test lint bench replay inject collector-smoke baseline-report
 
 build:
 	go build ./...
@@ -15,3 +15,16 @@ bench:
 replay:
 	go run ./cmd/faultreplay --scenario mixed --count 30 --out artifacts/fault-replay/fault_samples.jsonl
 	go run ./cmd/benchgen --out artifacts/benchmarks-replay --scenario mixed_faults --input artifacts/fault-replay/fault_samples.jsonl
+
+inject:
+	go run ./cmd/faultinject --scenario mixed --count 30 --out artifacts/fault-injection/raw_samples.jsonl
+
+collector-smoke:
+	go run ./cmd/faultinject --scenario mixed --count 12 --out artifacts/fault-injection/raw_samples.jsonl
+	go run ./cmd/collector --input artifacts/fault-injection/raw_samples.jsonl --output jsonl --output-path artifacts/collector/slo-events.jsonl
+
+baseline-report:
+	go run ./cmd/faultinject --scenario mixed --count 24 --out artifacts/fault-injection/raw_samples.jsonl
+	go run ./cmd/faultreplay --scenario mixed --count 24 --out artifacts/fault-replay/fault_samples.jsonl
+	go run ./cmd/benchgen --out artifacts/benchmarks-baseline --scenario mixed_faults --input artifacts/fault-replay/fault_samples.jsonl
+	cp artifacts/benchmarks-baseline/report.md docs/benchmarks/reports/baseline-attribution-latest.md

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ go run ./cmd/faultreplay --scenario mixed --count 30 --out artifacts/fault-repla
 ```bash
 go run ./cmd/benchgen --out artifacts/benchmarks-replay --scenario mixed_faults --input artifacts/fault-replay/fault_samples.jsonl
 ```
+10. Generate collector raw samples via fault injection harness:
+```bash
+go run ./cmd/faultinject --scenario mixed --count 24 --out artifacts/fault-injection/raw_samples.jsonl
+```
+11. Normalize injected raw samples with collector pipeline:
+```bash
+go run ./cmd/collector --input artifacts/fault-injection/raw_samples.jsonl --output jsonl --output-path artifacts/collector/slo-events.jsonl
+```
 
 ## Kubernetes Deployment Skeleton
 ```bash
@@ -43,10 +51,15 @@ kubectl apply -k deploy/k8s
 - `docs/strategy/differentiation-strategy.md`
 - `docs/strategy/why-this-exists-security-sre.md`
 - `docs/strategy/killer-demo-stories.md`
+- `docs/strategy/v0.2-build-plan.md`
+- `docs/strategy/v0.2-go-no-go-checklist.md`
 - `docs/benchmarks/llm-slo-attribution-accuracy.md`
 - `docs/benchmarks/output-schema.md`
 - `docs/contracts/v1/slo-event.schema.json`
 - `docs/contracts/v1/incident-attribution.schema.json`
+- `docs/contracts/v1alpha1/probe-event.schema.json`
+- `config/toolkit.schema.json`
+- `docs/security/self-hosted-runner-baseline.md`
 - `docs/research/landscape-sources.md`
 
 ## Positioning Snapshot
@@ -55,6 +68,7 @@ kubectl apply -k deploy/k8s
 - Wedge: LLM-specific SLI semantics + causal mapping from network/runtime events to user-facing SLO burn.
 
 ## Immediate Next Steps
-1. Build minimal DaemonSet collector prototype and emit schema-compliant events.
-2. Add fault-injection harness for attribution benchmark scenarios.
-3. Publish baseline attribution report under `docs/benchmarks/reports/`.
+1. Implement against `docs/strategy/v0.2-build-plan.md` and track release gates in `docs/strategy/v0.2-go-no-go-checklist.md`.
+2. Wire OTLP exporter mode for collector event output.
+3. Add DNS/provider/cgroup fault chaos scripts for in-cluster benchmark runs.
+4. Automate weekly baseline report publication from CI artifacts.

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -13,47 +15,141 @@ import (
 )
 
 func main() {
+	inputPath := flag.String("input", "-", "raw sample input JSONL path or '-' for stdin")
+	outputMode := flag.String("output", "stdout", "output mode: stdout|jsonl")
+	outputPath := flag.String("output-path", "artifacts/collector/slo-events.jsonl", "output path when output=jsonl")
+	cluster := flag.String("cluster", "local", "cluster name for synthetic generation")
+	namespace := flag.String("namespace", "default", "namespace for synthetic generation")
+	workload := flag.String("workload", "gateway", "workload for synthetic generation")
+	service := flag.String("service", "chat", "service for synthetic generation")
+	node := flag.String("k8s-node", "unknown-node", "node name label")
+	scenario := flag.String("scenario", "baseline", "synthetic scenario name")
+	count := flag.Int("count", 1, "synthetic sample count (0 = stream mode)")
+	intervalMS := flag.Int("interval-ms", 1000, "stream interval milliseconds when count=0")
+	flag.Parse()
+
 	schemaPath := filepath.Join("docs", "contracts", "v1", "slo-event.schema.json")
-	samples, err := readSamples(os.Stdin)
+	samples, err := loadInputSamples(*inputPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to read samples: %v\n", err)
 		os.Exit(1)
 	}
 
-	if len(samples) == 0 {
-		samples = append(samples, collector.RawSample{
-			Timestamp:        time.Now().UTC(),
-			Cluster:          "local",
-			Namespace:        "default",
-			Workload:         "demo",
-			Service:          "chat",
-			RequestID:        "req-1",
-			TraceID:          "trace-1",
-			TTFTMs:           420,
-			RequestLatencyMs: 850,
-			TokenTPS:         24,
-			ErrorRate:        0.01,
-		})
+	writer, closeFn, err := openOutput(*outputMode, *outputPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to open output: %v\n", err)
+		os.Exit(1)
+	}
+	defer closeFn()
+
+	if len(samples) > 0 {
+		if err := emitSamples(writer, schemaPath, samples); err != nil {
+			fmt.Fprintf(os.Stderr, "emit failed: %v\n", err)
+			os.Exit(1)
+		}
+		return
 	}
 
-	encoder := json.NewEncoder(os.Stdout)
+	meta := collector.SampleMeta{
+		Cluster:   *cluster,
+		Namespace: *namespace,
+		Workload:  *workload,
+		Service:   *service,
+		Node:      *node,
+	}
+
+	if *count < 0 {
+		fmt.Fprintln(os.Stderr, "count must be >= 0")
+		os.Exit(1)
+	}
+
+	if *count > 0 {
+		synthetic, genErr := collector.GenerateSyntheticSamples(*scenario, *count, time.Now().UTC(), meta)
+		if genErr != nil {
+			fmt.Fprintf(os.Stderr, "generate synthetic samples failed: %v\n", genErr)
+			os.Exit(1)
+		}
+		if err := emitSamples(writer, schemaPath, synthetic); err != nil {
+			fmt.Fprintf(os.Stderr, "emit failed: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	interval := time.Duration(*intervalMS) * time.Millisecond
+	if interval <= 0 {
+		fmt.Fprintln(os.Stderr, "interval-ms must be > 0")
+		os.Exit(1)
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for idx := 0; ; idx++ {
+		sample, genErr := collector.BuildSyntheticSample(*scenario, idx, time.Now().UTC(), meta)
+		if genErr != nil {
+			fmt.Fprintf(os.Stderr, "generate synthetic sample failed: %v\n", genErr)
+			os.Exit(1)
+		}
+		if err := emitSamples(writer, schemaPath, []collector.RawSample{sample}); err != nil {
+			fmt.Fprintf(os.Stderr, "emit failed: %v\n", err)
+			os.Exit(1)
+		}
+		<-ticker.C
+	}
+}
+
+func loadInputSamples(path string) ([]collector.RawSample, error) {
+	if path == "-" {
+		return readSamples(os.Stdin)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return readSamples(file)
+}
+
+func emitSamples(writer io.Writer, schemaPath string, samples []collector.RawSample) error {
+	encoder := json.NewEncoder(writer)
 	for _, sample := range samples {
 		events := collector.NormalizeSample(sample)
 		for _, event := range events {
 			if err := schema.ValidateAgainstSchema(schemaPath, event); err != nil {
-				fmt.Fprintf(os.Stderr, "schema validation failed: %v\n", err)
-				os.Exit(1)
+				return err
 			}
 			if err := encoder.Encode(event); err != nil {
-				fmt.Fprintf(os.Stderr, "encode error: %v\n", err)
-				os.Exit(1)
+				return err
 			}
 		}
 	}
+	return nil
 }
 
-func readSamples(file *os.File) ([]collector.RawSample, error) {
-	scanner := bufio.NewScanner(file)
+func openOutput(mode string, path string) (io.Writer, func(), error) {
+	switch mode {
+	case "stdout":
+		return os.Stdout, func() {}, nil
+	case "jsonl":
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return nil, func() {}, err
+		}
+		file, err := os.Create(path)
+		if err != nil {
+			return nil, func() {}, err
+		}
+		return file, func() {
+			if closeErr := file.Close(); closeErr != nil {
+				fmt.Fprintf(os.Stderr, "close output file failed: %v\n", closeErr)
+			}
+		}, nil
+	default:
+		return nil, func() {}, fmt.Errorf("unsupported output mode %q", mode)
+	}
+}
+
+func readSamples(reader io.Reader) ([]collector.RawSample, error) {
+	scanner := bufio.NewScanner(reader)
 	samples := make([]collector.RawSample, 0)
 	for scanner.Scan() {
 		line := scanner.Bytes()

--- a/cmd/faultinject/main.go
+++ b/cmd/faultinject/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ogulcanaydogan/llm-slo-ebpf-toolkit/pkg/collector"
+)
+
+func main() {
+	scenario := flag.String("scenario", "mixed", "fault injection scenario")
+	count := flag.Int("count", 24, "number of raw samples to emit")
+	out := flag.String(
+		"out",
+		"artifacts/fault-injection/raw_samples.jsonl",
+		"output JSONL file for collector input",
+	)
+	cluster := flag.String("cluster", "local", "cluster label")
+	namespace := flag.String("namespace", "default", "namespace label")
+	workload := flag.String("workload", "gateway", "workload label")
+	service := flag.String("service", "chat", "service label")
+	node := flag.String("node", "kind-control-plane", "node label")
+	flag.Parse()
+
+	meta := collector.SampleMeta{
+		Cluster:   *cluster,
+		Namespace: *namespace,
+		Workload:  *workload,
+		Service:   *service,
+		Node:      *node,
+	}
+	samples, err := collector.GenerateSyntheticSamples(*scenario, *count, time.Now().UTC(), meta)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "generate fault-injection samples failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(*out), 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "create output directory failed: %v\n", err)
+		os.Exit(1)
+	}
+	file, err := os.Create(*out)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "create output file failed: %v\n", err)
+		os.Exit(1)
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	for _, sample := range samples {
+		if err := encoder.Encode(sample); err != nil {
+			fmt.Fprintf(os.Stderr, "encode sample failed: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	fmt.Printf("wrote %d raw samples to %s\n", len(samples), *out)
+}

--- a/config/toolkit.schema.json
+++ b/config/toolkit.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://llm-slo-ebpf-toolkit.dev/config/v1alpha1/toolkit.schema.json",
+  "title": "ToolkitConfigV1Alpha1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "signal_set",
+    "sampling",
+    "correlation",
+    "otlp",
+    "safety"
+  ],
+  "properties": {
+    "signal_set": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": [
+          "dns_latency_ms",
+          "tcp_retransmits_total",
+          "runqueue_delay_ms",
+          "connect_latency_ms",
+          "tls_handshake_ms",
+          "cpu_steal_pct"
+        ]
+      },
+      "default": [
+        "dns_latency_ms",
+        "tcp_retransmits_total",
+        "runqueue_delay_ms",
+        "connect_latency_ms",
+        "tls_handshake_ms",
+        "cpu_steal_pct"
+      ]
+    },
+    "sampling": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "events_per_second_limit",
+        "burst_limit"
+      ],
+      "properties": {
+        "events_per_second_limit": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 10000
+        },
+        "burst_limit": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 20000
+        }
+      }
+    },
+    "correlation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "window_ms"
+      ],
+      "properties": {
+        "window_ms": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 2000
+        }
+      }
+    },
+    "otlp": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "endpoint"
+      ],
+      "properties": {
+        "endpoint": {
+          "type": "string",
+          "minLength": 1,
+          "default": "http://otel-collector:4317"
+        }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "max_overhead_pct"
+      ],
+      "properties": {
+        "max_overhead_pct": {
+          "type": "number",
+          "minimum": 0,
+          "default": 5
+        }
+      }
+    }
+  }
+}

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -15,4 +15,11 @@ kubectl delete -k deploy/k8s
 Notes:
 - The DaemonSet uses a privileged security context for eBPF access.
 - Update the container image in `deploy/k8s/daemonset.yaml` for your release.
+- Default collector args run synthetic mixed-fault stream mode (`--count=0`) for baseline SLO signal generation.
 - Manifests are intended as a baseline and should be adapted to your cluster hardening policy.
+
+Check emitted SLO events:
+
+```bash
+kubectl -n llm-slo-system logs -l app=llm-slo-collector --tail=20
+```

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -5,5 +5,7 @@ metadata:
   namespace: llm-slo-system
 data:
   collector-flags: |
-    --mode daemonset
-    --output jsonl
+    --scenario mixed
+    --count 0
+    --interval-ms 1000
+    --output stdout

--- a/deploy/k8s/daemonset.yaml
+++ b/deploy/k8s/daemonset.yaml
@@ -26,6 +26,14 @@ spec:
             capabilities:
               add: ["BPF", "SYS_ADMIN", "SYS_RESOURCE", "NET_ADMIN"]
           args:
+            - "--input=-"
+            - "--scenario=mixed"
+            - "--count=0"
+            - "--interval-ms=1000"
+            - "--cluster=local"
+            - "--namespace=default"
+            - "--workload=llm-slo-collector"
+            - "--service=collector"
             - "--k8s-node=$(NODE_NAME)"
             - "--output=stdout"
           env:

--- a/docs/benchmarks/llm-slo-attribution-accuracy.md
+++ b/docs/benchmarks/llm-slo-attribution-accuracy.md
@@ -11,6 +11,11 @@ Measure whether kernel-grounded telemetry improves LLM incident detection and fa
 2. Treatment A: eBPF toolkit only.
 3. Treatment B: combined mode (application instrumentation + eBPF toolkit).
 
+## Baseline Selection Rule
+- Preferred comparison set: `main` vs `v0.2-rc` vs previous stable tag.
+- If no previous stable tag exists, use first GA anchor tag as baseline.
+- All reports must state which baseline rule was used.
+
 ## Workload Profiles
 - Chat-only LLM service profile.
 - RAG-enabled profile with retrieval dependency.
@@ -37,14 +42,19 @@ Measure whether kernel-grounded telemetry improves LLM incident detection and fa
 - Attribution macro-F1 >= 0.85 on single-fault scenarios.
 - False positive rate <= 10%.
 - Abstain rate <= 15% on single-fault scenarios.
-- Collector CPU overhead <= 5% per node under target load.
+- Collector CPU overhead <= 5% per node for development and RC validation.
+- Collector CPU overhead <= 3% per node for GA release gate.
 - Collector memory overhead <= 250 MB per node in benchmark profile.
+- Full 6-signal requirement applies to CO-RE reference kernels.
+- BCC fallback runs are explicitly marked degraded capability and cannot claim full-signal coverage.
 
 ## Statistical Reporting Requirements
 - Publish confusion matrix and per-class precision/recall/F1.
 - Publish 95% confidence intervals for detection delay and macro-F1.
 - Publish run count, sample size, and class balance per scenario.
 - Publish abstain/uncertainty distribution by fault type.
+- Minimum repetitions for release claims: >=10 runs per profile/condition.
+- Fewer than 10 runs must be labeled exploratory and are non-gating.
 
 ## Measurement Method
 - Time-synchronized run controller marks fault start/end events.
@@ -57,6 +67,8 @@ Measure whether kernel-grounded telemetry improves LLM incident detection and fa
 - Publish exact fault injection scripts and seed values.
 - Capture raw outputs and report-generation code.
 - Re-run on fixed weekly profile to track drift.
+- Use nightly reduced-duration smoke scenarios for cost/runtime control.
+- Keep canonical full-duration scenario matrix in weekly benchmark runs.
 
 ## Required Artifacts Per Run
 - `artifacts/events/*.jsonl`

--- a/docs/benchmarks/reports/baseline-attribution-latest.md
+++ b/docs/benchmarks/reports/baseline-attribution-latest.md
@@ -1,0 +1,20 @@
+# Attribution Benchmark Report
+
+- Run ID: `2026-02-18T05-51-13Z`
+- Scenario: `mixed_faults`
+- Workload: `rag_mixed`
+- Attribution accuracy: `1.0000`
+- Detection delay median (s): `2.50`
+- False positive rate: `0.0000`
+- False negative rate: `0.0000`
+- Burn-rate prediction error: `0.0700`
+- Collector CPU overhead (%): `2.20`
+- Collector memory overhead (MB): `120.00`
+
+## Bundle
+
+- `incident_predictions.csv`
+- `confusion-matrix.csv`
+- `collector_overhead.csv`
+- `attribution_summary.json`
+- `provenance.json`

--- a/docs/benchmarks/reports/template.md
+++ b/docs/benchmarks/reports/template.md
@@ -14,6 +14,8 @@
 - Fault Injection Matrix Covered:
 - Sample Size:
 - Confidence Level:
+- Baseline rule used (previous stable or first GA anchor fallback):
+- Run class (`gating` when >=10 repetitions/profile, else `exploratory`):
 
 ## Key Results
 - Detection delay median (with CI95):
@@ -23,6 +25,7 @@
 - Abstain rate:
 - Burn-rate prediction error:
 - Collector overhead (CPU/memory/events/drops):
+- Capability mode (`core_full` or `bcc_degraded`):
 
 ## Failure and Drift Checks
 - Artifact completeness check:

--- a/docs/benchmarks/reports/weekly-2026-02-17.md
+++ b/docs/benchmarks/reports/weekly-2026-02-17.md
@@ -2,11 +2,13 @@
 
 ## Scope
 - Collector + attribution baseline.
-- Added runtime-oriented delivery kit: Kubernetes DaemonSet skeleton, multi-domain fault replay runner, and report bundle output.
+- Added runtime-oriented delivery kit: Kubernetes DaemonSet stream mode, multi-domain fault replay runner, raw fault injection harness, and report bundle output.
 
 ## Test Summary
 - `go test ./...`: pass
 - `go run ./cmd/faultreplay --scenario mixed --count 24 --out /tmp/fault_samples.jsonl`: pass
+- `go run ./cmd/faultinject --scenario mixed --count 16 --out /tmp/faultinject_raw.jsonl`: pass
+- `go run ./cmd/collector --input /tmp/faultinject_raw.jsonl --output jsonl --output-path /tmp/slo_events.jsonl`: pass
 - `go run ./cmd/benchgen --out artifacts/benchmarks-ci --scenario mixed_faults --input /tmp/fault_samples.jsonl`: pass
 - `go run ./cmd/collector`: pass (schema-valid JSONL output)
 - `go run ./cmd/attributor --out <file> --summary-out <file> --confusion-out <file>`: pass
@@ -18,6 +20,7 @@
 - `attribution_summary.json`
 - `provenance.json`
 - `report.md`
+- Published baseline report: `docs/benchmarks/reports/baseline-attribution-latest.md`
 
 ## Deployment Snapshot
 - Added `deploy/k8s` manifests:
@@ -27,5 +30,5 @@
 
 ## Known Limitations
 - Collector container image is a placeholder until release pipeline publishes runtime images.
-- Fault replay is synthetic and deterministic; live fault injector integration remains pending.
+- Fault replay and injection are synthetic and deterministic; in-cluster chaos hooks are not wired yet.
 - Attribution remains rule-based and is tuned for low-cardinality scenarios.

--- a/docs/contracts/v1alpha1/README.md
+++ b/docs/contracts/v1alpha1/README.md
@@ -1,0 +1,10 @@
+# v1alpha1 Contracts
+
+This folder contains internal pre-GA schemas used for v0.2 implementation.
+
+## Files
+- `probe-event.schema.json`: normalized eBPF probe event payload (`ProbeEventV1`).
+
+## Compatibility Notes
+- External compatibility guarantees remain anchored to `docs/contracts/v1/*`.
+- `v1alpha1` contracts may evolve until promoted to stable `v1`.

--- a/docs/contracts/v1alpha1/probe-event.schema.json
+++ b/docs/contracts/v1alpha1/probe-event.schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://llm-slo-ebpf-toolkit.dev/contracts/v1alpha1/probe-event.schema.json",
+  "title": "ProbeEventV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ts_unix_nano",
+    "signal",
+    "node",
+    "namespace",
+    "pod",
+    "container",
+    "pid",
+    "tid",
+    "value",
+    "unit",
+    "status"
+  ],
+  "properties": {
+    "ts_unix_nano": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "signal": {
+      "type": "string"
+    },
+    "node": {
+      "type": "string"
+    },
+    "namespace": {
+      "type": "string"
+    },
+    "pod": {
+      "type": "string"
+    },
+    "container": {
+      "type": "string"
+    },
+    "pid": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "tid": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "conn_tuple": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "src_ip",
+        "dst_ip",
+        "src_port",
+        "dst_port",
+        "protocol"
+      ],
+      "properties": {
+        "src_ip": {
+          "type": "string"
+        },
+        "dst_ip": {
+          "type": "string"
+        },
+        "src_port": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 65535
+        },
+        "dst_port": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 65535
+        },
+        "protocol": {
+          "type": "string"
+        }
+      }
+    },
+    "value": {
+      "type": "number"
+    },
+    "unit": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "ok",
+        "warning",
+        "error"
+      ]
+    },
+    "trace_id": {
+      "type": "string"
+    },
+    "span_id": {
+      "type": "string"
+    },
+    "errno": {
+      "type": "integer"
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    }
+  }
+}

--- a/docs/security/self-hosted-runner-baseline.md
+++ b/docs/security/self-hosted-runner-baseline.md
@@ -1,0 +1,34 @@
+# Self-Hosted Runner Security Baseline (Privileged eBPF CI)
+
+Scope: nightly and weekly Linux jobs that require privileged eBPF and kind integration.
+
+## Required Controls
+1. Ephemeral runners only.
+- One job, one runner lifecycle.
+- Runner is destroyed after each workflow.
+
+2. Isolated execution environment.
+- Dedicated node pool or standalone host class for CI runners.
+- No co-location with production workloads.
+
+3. Credential minimization.
+- Short-lived tokens only.
+- No long-lived cloud keys on runner disk.
+- Least-privilege repository and artifact permissions.
+
+4. Artifact and log hygiene.
+- Scrub secrets and environment material before artifact upload.
+- Reject uploads that contain kubeconfigs, tokens, or private keys.
+
+5. Network policy posture.
+- Restrict egress to required package mirrors, registry, and GitHub endpoints.
+- Block lateral movement to internal non-CI systems.
+
+6. Host hardening.
+- Keep kernel and container runtime patched.
+- Enforce audit logging for privileged job startup, teardown, and artifact upload actions.
+
+## Workflow Requirements
+- PR CI on GitHub-hosted runners must not require privileged eBPF execution.
+- Privileged jobs run only on trusted branches and scheduled workflows.
+- Weekly full benchmark jobs must publish provenance metadata for traceability.

--- a/docs/strategy/v0.2-build-plan.md
+++ b/docs/strategy/v0.2-build-plan.md
@@ -1,0 +1,90 @@
+# LLM SLO eBPF Toolkit v0.2 Build Plan
+
+Status: Approved working plan  
+Plan date: 2026-02-18
+
+## Locked Decisions
+- Primary language: Go.
+- Local cluster: kind (3-node default profile).
+- Observability stack: Grafana + Prometheus + Tempo + OTel Collector.
+- eBPF path: libbpf CO-RE primary; BCC fallback for non-BTF hosts.
+- Overhead gates: development <=5% CPU overhead; GA <=3%.
+- Deterministic LLM backend for local incident and benchmark runs.
+- Privileged eBPF integration runs on self-hosted Linux CI only.
+
+## Current Anchors to Preserve
+- `docs/contracts/v1/slo-event.schema.json`
+- `docs/contracts/v1/incident-attribution.schema.json`
+
+External outputs keep v1 compatibility. New probe-level schema is introduced under `v1alpha1`.
+
+## Corrected Design Decisions (Release-Critical)
+
+### 1) Correlation threshold and enrichment consistency
+- Join confidence tiers:
+  - exact `trace_id` in window: `1.0`
+  - `pod+pid` in <=100ms: `0.9`
+  - `pod+conn_tuple` in <=250ms: `0.8`
+  - `service+node` in <=500ms: `0.65` (debug only)
+- Span enrichment rule remains `confidence >= 0.7`.
+- Outcome: `0.65` tier contributes unmatched/diagnostic views only, never hard span enrichment.
+
+### 2) Required signal set vs fallback mode
+- CO-RE reference environments must satisfy full 6-signal coverage.
+- BCC fallback is explicitly a degraded mode (DNS + retransmits only).
+- GA blocking gate applies to CO-RE reference kernels; fallback does not block GA but must surface capability flags in reports.
+
+### 3) Config schema normalization
+- `config/toolkit.schema.json` uses nested objects, not dotted-key pseudo-fields.
+- Required structure:
+  - `signal_set`
+  - `sampling`
+  - `correlation.window_ms`
+  - `otlp.endpoint`
+  - `safety.max_overhead_pct`
+
+### 4) Benchmark statistical power
+- Minimum repetitions per profile: 10 (not 5) for distribution claims.
+- If fewer than 10 runs, results are marked exploratory and cannot gate release.
+- Report requires CI95 for latency and attribution metrics plus run count and class balance.
+
+### 5) CI runtime partitioning
+- Nightly: short smoke subset (DNS, retransmit, CPU) with reduced phase durations.
+- Weekly: full scenario matrix and release-tag comparisons.
+- Goal: preserve signal quality without making nightly pipelines impractical.
+
+### 6) Self-hosted runner security baseline
+- Ephemeral runner instances per privileged job.
+- Isolated node pool with no shared production credentials.
+- Artifact scrubbing before publish/upload.
+- Minimal scoped tokens and short-lived credentials only.
+
+### 7) Initial release baseline rule
+- If no prior stable tag exists, use first GA anchor tag as baseline reference.
+- Comparison matrix rule:
+  - preferred: `main` vs `v0.2-rc` vs previous stable
+  - fallback: `main` vs `v0.2-rc` vs first GA anchor
+
+## Milestone Windows and Hard Gates
+
+| Milestone | Dates (2026) | Must-Ship | Hard Gate |
+|---|---|---|---|
+| M0 Bootstrap | Feb 17-Feb 23 | Buildable repo, kind bootstrap, CI build/lint/unit, DS heartbeat | `make build` and `make test` on clean env |
+| M1 Demo + OTel | Feb 24-Mar 2 | Streaming demo, baseline TTFT/tokens/sec, first correlated signal | MVP checkpoint by Mar 2 |
+| M2 Signals v1 | Mar 3-Mar 16 | Six CO-RE signals, schema, enricher, safety toggles | overhead <=5% (dev gate) |
+| M3 Correlation | Mar 17-Mar 23 | Collector correlator, retrieval decomposition, retry storm detector | precision >=0.90 and recall >=0.85 |
+| M4 Incident Lab | Mar 24-Mar 30 | 6 deterministic scenarios, dashboards, alerts | v0.2 RC by Mar 30 |
+| M5 Bench + Release | Mar 31-Apr 13 | Tag replay, regression gates, SBOM/provenance, GA docs | v0.2 GA by Apr 13 and overhead <=3% |
+
+## Deterministic Harness Defaults
+- Seed: `42`
+- Load profile: `rag_mixed_20rps`
+- Full phase durations: baseline `10m`, fault `10m`, recovery `5m`
+- Nightly smoke profile may use reduced durations; weekly full run uses canonical durations.
+
+## Acceptance Summary for v0.2 GA
+- CO-RE reference validation passes six-signal requirement.
+- Correlation precision >=0.90 and recall >=0.85 on labeled set.
+- Overhead gate <=3% CPU on baseline profile.
+- Incident reproducibility variance <=10% across three reruns.
+- Signed release with SBOM, provenance, and benchmark appendix.

--- a/docs/strategy/v0.2-go-no-go-checklist.md
+++ b/docs/strategy/v0.2-go-no-go-checklist.md
@@ -1,0 +1,68 @@
+# v0.2 Go/No-Go Checklist
+
+Use this checklist at RC cut and GA cut.  
+Decision rule: any blocking gate marked `FAIL` is a `NO-GO`.
+
+## A. Contract and API Gates
+
+| Gate | Pass Criteria | Blocker |
+|---|---|---|
+| A1 v1 contract compatibility | No breaking changes in `docs/contracts/v1/*` | Yes |
+| A2 v1alpha1 probe schema | `docs/contracts/v1alpha1/probe-event.schema.json` present and validated | Yes |
+| A3 config schema structure | `config/toolkit.schema.json` uses nested required fields (not dotted pseudo-keys) | Yes |
+| A4 semconv consistency | Required `llm.ebpf.*` and `llm.slo.*` keys defined and used consistently | Yes |
+
+## B. Signal and Runtime Gates
+
+| Gate | Pass Criteria | Blocker |
+|---|---|---|
+| B1 CO-RE signal coverage | 6/6 required signals pass on reference kernels | Yes |
+| B2 fallback capability flagging | BCC mode reports degraded capability explicitly | Yes |
+| B3 runtime safety controls | per-signal toggles, rate limiter, degrade mode verified | Yes |
+| B4 overhead dev gate | <=5% CPU overhead during development builds | Yes for RC |
+| B5 overhead GA gate | <=3% CPU overhead at GA candidate | Yes for GA |
+
+## C. Correlation Quality Gates
+
+| Gate | Pass Criteria | Blocker |
+|---|---|---|
+| C1 join precedence | Confidence tiers implemented exactly as plan | Yes |
+| C2 enrichment threshold | Span enrichment only when confidence >=0.7 | Yes |
+| C3 debug-only low confidence | 0.65 tier events exported only for diagnostics | Yes |
+| C4 accuracy gate | Precision >=0.90 and Recall >=0.85 on labeled integration set | Yes |
+| C5 fanout control | Max join fanout 1:3 enforced | Yes |
+
+## D. Incident and Reproducibility Gates
+
+| Gate | Pass Criteria | Blocker |
+|---|---|---|
+| D1 deterministic harness | seed/load profile/phase defaults reproducible | Yes |
+| D2 scenario coverage | 6 required scenarios implemented with pass/fail assertions | Yes |
+| D3 rerun variance | <=10% variance across three reruns per scenario | Yes |
+| D4 required artifact bundle | `summary.md`, `attribution_summary.json`, `incident_predictions.csv`, `collector_overhead.csv`, `provenance.json` | Yes |
+
+## E. Benchmark and Statistics Gates
+
+| Gate | Pass Criteria | Blocker |
+|---|---|---|
+| E1 minimum repetitions | >=10 runs/profile for release-claim metrics | Yes |
+| E2 CI reporting | CI95 and class balance published in report | Yes |
+| E3 significance rule | Mann-Whitney/bootstrap gate configured and enforced | Yes |
+| E4 baseline selection | previous stable tag used, else first GA anchor fallback | Yes |
+
+## F. CI/CD and Security Gates
+
+| Gate | Pass Criteria | Blocker |
+|---|---|---|
+| F1 PR CI | build/lint/unit/schema checks all green | Yes |
+| F2 nightly Linux integration | privileged smoke suite green (DNS/retransmit/CPU) | Yes |
+| F3 weekly full benchmark | tag matrix and full incident matrix complete | Yes |
+| F4 runner isolation | ephemeral privileged runners and isolated node pool | Yes |
+| F5 supply-chain release | signed artifacts, SBOM, checksums, provenance | Yes |
+
+## Decision Log
+
+| Date | Stage | Decision | Notes |
+|---|---|---|---|
+| YYYY-MM-DD | RC | GO/NO-GO |  |
+| YYYY-MM-DD | GA | GO/NO-GO |  |

--- a/pkg/collector/pipeline_test.go
+++ b/pkg/collector/pipeline_test.go
@@ -12,12 +12,14 @@ func TestNormalizeSampleProducesEvents(t *testing.T) {
 		Namespace:        "default",
 		Workload:         "demo",
 		Service:          "chat",
+		Node:             "kind-control-plane",
 		RequestID:        "req-1",
 		TraceID:          "trace-1",
 		TTFTMs:           300,
 		RequestLatencyMs: 900,
 		TokenTPS:         20,
 		ErrorRate:        0.01,
+		FaultLabel:       "provider_throttle",
 	}
 
 	events := NormalizeSample(sample)
@@ -29,6 +31,12 @@ func TestNormalizeSampleProducesEvents(t *testing.T) {
 	}
 	if events[1].Status != "warning" {
 		t.Fatalf("expected warning status, got %s", events[1].Status)
+	}
+	if events[0].Labels["node"] != "kind-control-plane" {
+		t.Fatalf("expected node label")
+	}
+	if events[0].Labels["fault_label"] != "provider_throttle" {
+		t.Fatalf("expected fault label")
 	}
 }
 

--- a/pkg/collector/synthetic.go
+++ b/pkg/collector/synthetic.go
@@ -1,0 +1,118 @@
+package collector
+
+import (
+	"fmt"
+	"time"
+)
+
+// SampleMeta identifies the workload attributes attached to generated samples.
+type SampleMeta struct {
+	Cluster   string
+	Namespace string
+	Workload  string
+	Service   string
+	Node      string
+}
+
+var syntheticScenarioSequence = map[string][]string{
+	"baseline":          {"baseline"},
+	"provider_throttle": {"provider_throttle"},
+	"dns_latency":       {"dns_latency"},
+	"cpu_throttle":      {"cpu_throttle"},
+	"memory_pressure":   {"memory_pressure"},
+	"mixed":             {"provider_throttle", "dns_latency", "cpu_throttle", "memory_pressure"},
+}
+
+// SupportedSyntheticScenarios returns accepted synthetic scenario names.
+func SupportedSyntheticScenarios() []string {
+	return []string{
+		"baseline",
+		"provider_throttle",
+		"dns_latency",
+		"cpu_throttle",
+		"memory_pressure",
+		"mixed",
+	}
+}
+
+// GenerateSyntheticSamples creates scenario-specific collector inputs.
+func GenerateSyntheticSamples(
+	scenario string,
+	count int,
+	start time.Time,
+	meta SampleMeta,
+) ([]RawSample, error) {
+	if count < 1 {
+		return nil, fmt.Errorf("count must be >= 1")
+	}
+
+	out := make([]RawSample, 0, count)
+	for idx := 0; idx < count; idx++ {
+		ts := start.Add(time.Duration(idx) * time.Second)
+		sample, err := BuildSyntheticSample(scenario, idx, ts, meta)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, sample)
+	}
+	return out, nil
+}
+
+// BuildSyntheticSample returns one scenario-specific sample for the given index.
+func BuildSyntheticSample(
+	scenario string,
+	idx int,
+	timestamp time.Time,
+	meta SampleMeta,
+) (RawSample, error) {
+	labels, ok := syntheticScenarioSequence[scenario]
+	if !ok {
+		return RawSample{}, fmt.Errorf("unsupported scenario %q", scenario)
+	}
+	faultLabel := labels[idx%len(labels)]
+	return buildScenarioSample(meta, timestamp, idx, faultLabel), nil
+}
+
+func buildScenarioSample(meta SampleMeta, timestamp time.Time, idx int, faultLabel string) RawSample {
+	requestID := fmt.Sprintf("collector-req-%04d", idx+1)
+	traceID := fmt.Sprintf("collector-trace-%04d", idx+1)
+	sample := RawSample{
+		Timestamp:        timestamp,
+		Cluster:          meta.Cluster,
+		Namespace:        meta.Namespace,
+		Workload:         meta.Workload,
+		Service:          meta.Service,
+		Node:             meta.Node,
+		RequestID:        requestID,
+		TraceID:          traceID,
+		TTFTMs:           340,
+		RequestLatencyMs: 720,
+		TokenTPS:         36,
+		ErrorRate:        0.005,
+		FaultLabel:       faultLabel,
+	}
+
+	switch faultLabel {
+	case "provider_throttle":
+		sample.TTFTMs = 980
+		sample.RequestLatencyMs = 2100
+		sample.TokenTPS = 7
+		sample.ErrorRate = 0.14
+	case "dns_latency":
+		sample.TTFTMs = 820
+		sample.RequestLatencyMs = 1600
+		sample.TokenTPS = 18
+		sample.ErrorRate = 0.03
+	case "cpu_throttle":
+		sample.TTFTMs = 700
+		sample.RequestLatencyMs = 1350
+		sample.TokenTPS = 11
+		sample.ErrorRate = 0.05
+	case "memory_pressure":
+		sample.TTFTMs = 650
+		sample.RequestLatencyMs = 1250
+		sample.TokenTPS = 13
+		sample.ErrorRate = 0.04
+	}
+	return sample
+}

--- a/pkg/collector/synthetic_test.go
+++ b/pkg/collector/synthetic_test.go
@@ -1,0 +1,36 @@
+package collector
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGenerateSyntheticSamplesMixed(t *testing.T) {
+	meta := SampleMeta{
+		Cluster:   "local",
+		Namespace: "default",
+		Workload:  "gateway",
+		Service:   "chat",
+		Node:      "kind-control-plane",
+	}
+	samples, err := GenerateSyntheticSamples("mixed", 6, time.Unix(0, 0).UTC(), meta)
+	if err != nil {
+		t.Fatalf("generate samples: %v", err)
+	}
+	if len(samples) != 6 {
+		t.Fatalf("expected 6 samples, got %d", len(samples))
+	}
+	if samples[0].FaultLabel != "provider_throttle" {
+		t.Fatalf("unexpected first fault label: %s", samples[0].FaultLabel)
+	}
+	if samples[0].Node != "kind-control-plane" {
+		t.Fatalf("expected node label to propagate")
+	}
+}
+
+func TestGenerateSyntheticSamplesRejectsUnknownScenario(t *testing.T) {
+	meta := SampleMeta{}
+	if _, err := GenerateSyntheticSamples("unknown", 2, time.Now().UTC(), meta); err == nil {
+		t.Fatal("expected unsupported scenario error")
+	}
+}


### PR DESCRIPTION
## Summary
- add collector runtime stream mode (`--count=0`) with schema-validated JSONL output and synthetic scenario generation
- add fault injection command (`cmd/faultinject`) producing raw collector sample streams
- enrich normalized SLO events with `node` and `fault_label` labels
- add baseline report publishing flow and update CI/Makefile/deploy docs for new runtime path
- include v0.2 planning/schema/supporting docs (`config`, `v1alpha1`, security baseline)

## Validation
- go test ./...
- make collector-smoke
- make baseline-report
