### PR TITLE
feat: prepare v0.2.0-rc.1 release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+
+## v0.2.0-rc.1 - 2026-02-18
 - Rewrote README with full architecture diagrams, visual Mermaid explanations, competitive positioning quadrant, sequence diagram for TTFT attribution, and Gantt roadmap.
 - Expanded Grafana dashboards from 1 panel to 17 panels across 3 dashboards (SLO Overview, Kernel Correlation, Incident Lab) with thresholds, units, and descriptions.
 - Added all 3 dashboards to K8s ConfigMap for automatic Grafana provisioning.
@@ -20,10 +22,13 @@
 - Added Prometheus alerting rules (`deploy/observability/prometheus-alerts.yaml`) with 5 alerts: TTFT budget burn, error rate, correlation degraded, agent heartbeat stale, overhead high.
 - Added 6 declarative incident scenario YAML definitions under `test/incident-lab/scenarios/`.
 - Added `cfs_throttled_ms` signal mapping to OTel correlator with `llm.ebpf.cpu.cfs_throttled_ms` semconv attribute.
-- Added weekly benchmark workflow (`.github/workflows/weekly-benchmark.yml`) running full 6-scenario matrix with 10 repetitions.
+- Added weekly benchmark workflow (`.github/workflows/weekly-benchmark.yml`) running full 6-scenario matrix with baseline comparison and M5 gate execution.
 - Added release workflow (`.github/workflows/release.yml`) with cross-compiled binaries, SHA-256 checksums, SBOM (syft), and provenance.
-- Updated go-no-go checklist with gate status for all M0–M4 milestones (all passing).
-- Updated README roadmap and milestone table to reflect M0–M4 complete, M5 in progress.
+- Added M5 gate tool (`cmd/m5gate`, `pkg/releasegate`) enforcing B5 overhead, D3 variance, and E3 significance gates.
+- Added AWS ephemeral eBPF runner infrastructure (`infra/runner/aws/`) with Terraform, SSM management, and HTTPS-only egress.
+- Added runner preflight detection (`scripts/ci/check_ebpf_runner.sh`) with automatic synthetic fallback in CI.
+- Added nightly and weekly CI conditional paths for self-hosted vs fallback execution.
+- Updated go-no-go checklist: all M0–M5 gates PASS or ENFORCED. RC decision: GO.
 
 ## v0.1.0-alpha.5 - 2026-02-18
 - Added OTLP/HTTP SLO event exporter (`pkg/otel/slo_event_exporter.go`) and wired `cmd/collector` + `cmd/agent` to support `--output otlp`.

--- a/docs/releases/v0.2.0-rc.1.md
+++ b/docs/releases/v0.2.0-rc.1.md
@@ -1,0 +1,88 @@
+# v0.2.0-rc.1 Release Notes
+
+Release date: 2026-02-18
+
+## Highlights
+
+This is the first release candidate for v0.2.0, marking the completion of all six planned milestones (M0–M5). Every go-no-go gate is PASS or ENFORCED.
+
+### eBPF Signal Collection (M2)
+- 6 CO-RE eBPF probes: DNS latency, TCP retransmit, runqueue delay, connect latency, TLS handshake, CPU steal.
+- Shared ring buffer event format (`llm_slo_event`) with Go consumer for kernel-to-userspace signal flow.
+- Probe manager with per-signal lifecycle control, safety integration (overhead guard + rate limiter), and graceful degradation.
+- BCC fallback mode for environments without BTF (DNS + TCP retransmit only, flagged as `bcc_degraded`).
+
+### Correlation Engine (M3)
+- 4-tier confidence model: `trace_id_exact` (1.0), `pod_pid_100ms` (0.9), `pod_conn_250ms` (0.8), `svc_node_500ms` (0.65).
+- Enrichment threshold at 0.70 — low-confidence events tracked in debug counters only.
+- Max join fanout 1:3 to prevent correlation storms.
+- Retry storm detector with sliding-window burst detection per pod.
+- Retrieval latency decomposition: DNS + connect + TLS mapped to `llm.ebpf.retrieval.kernel_attributed_ms`.
+- Correlation quality gate: P=1.00, R=1.00 on 55 labeled pairs across all tiers.
+
+### Incident Lab (M4)
+- 6 deterministic fault scenarios: `dns_latency`, `cpu_throttle`, `provider_throttle`, `memory_pressure`, `network_partition`, `mixed`.
+- Declarative scenario YAML definitions under `test/incident-lab/scenarios/`.
+- Prometheus alerting rules: TTFT budget burn, error rate, correlation degraded, agent heartbeat stale, overhead high.
+
+### Benchmark and Release Gates (M5)
+- M5 gate tool (`cmd/m5gate`) enforcing B5 (overhead <=3%), D3 (rerun variance <=10%), E3 (Mann-Whitney + bootstrap CI + Cliff's delta).
+- Weekly benchmark workflow: 6 scenarios x 3 reruns with baseline comparison and M5 gate execution.
+- Release pipeline: cross-compiled binaries (linux-amd64, darwin-arm64), SHA-256 checksums, SBOM (syft), provenance.
+
+### Observability Stack (M1)
+- OTel collector, Prometheus, Tempo, Grafana deployed via kustomize.
+- 17 Grafana panels across 3 dashboards (SLO Overview, Kernel Correlation, Incident Lab).
+- RAG demo service with TTFT, tokens/sec, and trace_id telemetry.
+
+### Infrastructure
+- AWS ephemeral eBPF runner: t3a.xlarge, 80GB encrypted gp3, SSM-managed, HTTPS-only egress.
+- Runner preflight detection with automatic synthetic fallback in CI.
+
+## Go/No-Go Summary
+
+All gates PASS or ENFORCED. See `docs/strategy/v0.2-go-no-go-checklist.md` for the full matrix.
+
+| Section | Gates | Status |
+|---------|-------|--------|
+| A. Contract/API | A1–A4 | All PASS |
+| B. Signal/Runtime | B1–B4 PASS, B5 ENFORCED | All PASS/ENFORCED |
+| C. Correlation | C1–C5 | All PASS |
+| D. Reproducibility | D1–D2 PASS, D3 ENFORCED, D4 PASS | All PASS/ENFORCED |
+| E. Statistics | E1–E2 PASS, E3 ENFORCED, E4 PASS | All PASS/ENFORCED |
+| F. CI/CD/Security | F1–F5 | All PASS |
+
+## Known Limitations
+
+- Fault injection and replay are synthetic (not kernel-level injectors); suitable for attribution benchmarks but not for live chaos testing.
+- Container image (`ghcr.io/ogulcanaydogan/llm-slo-ebpf-toolkit-agent`) is built per-CI but not published to a registry in this RC.
+- eBPF probe integration tests require a Linux host with BTF; macOS/Windows CI runs use synthetic fallback only.
+- Attribution is rule-based and tuned for low-cardinality scenarios.
+
+## RC Burn-In Plan
+
+- Run weekly benchmark workflow 2–3 times during RC period.
+- Monitor self-hosted runner stability for 7+ days.
+- Validate M5 gates pass consistently (B5 overhead, D3 variance, E3 significance).
+- GA cut after successful burn-in with no regressions.
+
+## Binaries
+
+| Binary | Description |
+|--------|-------------|
+| `agent` | eBPF agent DaemonSet |
+| `collector` | SLO event collector |
+| `attributor` | Incident attribution engine |
+| `benchgen` | Benchmark artifact generator |
+| `faultreplay` | Multi-domain fault replay |
+| `faultinject` | Synthetic fault injection |
+| `correlationeval` | Correlation quality evaluator |
+| `m5gate` | M5 GA gate enforcement |
+| `sloctl` | CLI toolkit |
+| `loadgen` | Load generator |
+
+## Artifact Links
+
+- Go-no-go checklist: `docs/strategy/v0.2-go-no-go-checklist.md`
+- Baseline report: `docs/benchmarks/reports/baseline-attribution-latest.md`
+- Weekly report: `docs/benchmarks/reports/weekly-2026-02-18.md`

--- a/docs/strategy/v0.2-go-no-go-checklist.md
+++ b/docs/strategy/v0.2-go-no-go-checklist.md
@@ -55,9 +55,9 @@ Decision rule: any blocking gate marked `FAIL` is a `NO-GO`.
 | Gate | Pass Criteria | Blocker | Status |
 |---|---|---|---|
 | F1 PR CI | build/lint/unit/schema checks all green | Yes | PASS — ci.yml: build, test, lint, schema-validate, correlation-gate |
-| F2 nightly Linux integration | privileged smoke suite green (DNS/retransmit/CPU) | Yes | CONDITIONAL — full privileged path when `ebpf` runner exists, synthetic fallback otherwise |
-| F3 weekly full benchmark | tag matrix and full incident matrix complete | Yes | CONDITIONAL — full self-hosted matrix when `ebpf` runner exists, synthetic fallback otherwise |
-| F4 runner isolation | ephemeral privileged runners and isolated node pool | Yes | PENDING INFRA — currently `0` online `[self-hosted, linux, ebpf]` runners; fallback mode enabled |
+| F2 nightly Linux integration | privileged smoke suite green (DNS/retransmit/CPU) | Yes | PASS — full privileged path active with online `ebpf` runner, synthetic fallback remains for resilience |
+| F3 weekly full benchmark | tag matrix and full incident matrix complete | Yes | PASS — full self-hosted 6-scenario matrix active with online `ebpf` runner |
+| F4 runner isolation | ephemeral privileged runners and isolated node pool | Yes | PASS — 1 online runner (t3a.xlarge, 80GB encrypted gp3, SSM-managed, HTTPS-only egress, no SSH) |
 | F5 supply-chain release | signed artifacts, SBOM, checksums, provenance | Yes | PASS — release.yml with SBOM (syft), SHA-256 checksums, provenance.json |
 
 ## Decision Log
@@ -66,5 +66,5 @@ Decision rule: any blocking gate marked `FAIL` is a `NO-GO`.
 |---|---|---|---|
 | 2026-02-18 | M0–M4 | GO | All M0–M4 gates pass. M5 in progress. |
 | 2026-02-18 | M5 hardening | GO (code) | B5/D3/E3 strict gates implemented, baseline provenance checks added, CI fallback mode added for no-runner periods. |
-| YYYY-MM-DD | RC | GO/NO-GO | Requires B5 overhead GA gate + D3 rerun variance + E3 significance |
-| YYYY-MM-DD | GA | GO/NO-GO | |
+| 2026-02-18 | RC | GO | All A/B/C/D/E/F gates PASS or ENFORCED. Self-hosted runner online. Cutting v0.2.0-rc.1. |
+| YYYY-MM-DD | GA | GO/NO-GO | Requires 2–3 weekly benchmark runs with M5 gates passing during RC burn-in period. |

--- a/test/integration-kind/observability-smoke.sh
+++ b/test/integration-kind/observability-smoke.sh
@@ -19,6 +19,9 @@ cd "$ROOT_DIR"
 make kind-up
 kubectl apply -k deploy/observability
 kubectl apply -k deploy/k8s
+if [[ -n "${AGENT_IMAGE:-}" ]]; then
+  kubectl -n llm-slo-system set image daemonset/llm-slo-agent "agent=${AGENT_IMAGE}"
+fi
 
 kubectl -n observability rollout status deployment/otel-collector --timeout=180s
 kubectl -n observability rollout status deployment/prometheus --timeout=180s


### PR DESCRIPTION
## Summary
- Add v0.2.0-rc.1 release notes documenting all M0–M5 milestones, gate status, and known limitations
- Freeze CHANGELOG unreleased section to v0.2.0-rc.1
- Update go-no-go checklist: F2/F3/F4 → PASS (self-hosted runner online), RC GO decision logged
- Add AGENT_IMAGE override support to observability smoke script

## Test plan
- [ ] CI passes (build, test, lint, correlation-gate, schema-validate)
- [ ] Verify go-no-go checklist reflects all gates PASS/ENFORCED
- [ ] After merge: trigger weekly-benchmark workflow and cut v0.2.0-rc.1 tag