### PR TITLE
docs: fix formatting in OpenSSF badge guide

### DIFF
--- a/docs/grants/openssf-badge-guide.md
+++ b/docs/grants/openssf-badge-guide.md
@@ -1,4 +1,4 @@
-# OpenSSF Best Practices Badge — Submission Guide
+# OpenSSF Best Practices Badge: Submission Guide
 
 > **URL:** https://www.bestpractices.dev/
 > **Time:** ~30 minutes


### PR DESCRIPTION
## Summary
- Replace em dash with colon in document title for consistency