### PR TITLE
chore(ci): node24 action runtime cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
   pr-gates:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.23"
       - name: Go build
@@ -25,7 +25,7 @@ jobs:
       - name: Schema validation
         run: make schema-validate
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v1.60
       - name: Collector fault-injection smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.60
+          version: v2.11.4
       - name: Collector fault-injection smoke
         run: |
           go run ./cmd/faultinject --scenario mixed --count 16 --out /tmp/faultinject_raw.jsonl

--- a/.github/workflows/e2e-evidence-report.yml
+++ b/.github/workflows/e2e-evidence-report.yml
@@ -17,7 +17,7 @@ jobs:
       runner_count: ${{ steps.detect.outputs.runner_count }}
       reason: ${{ steps.detect.outputs.reason }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: detect
         env:
           RUNNER_STATUS_TOKEN: ${{ secrets.RUNNER_STATUS_TOKEN }}
@@ -31,8 +31,8 @@ jobs:
     runs-on: [self-hosted, linux, ebpf]
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.23"
       - name: Build local demo images for kind
@@ -69,7 +69,7 @@ jobs:
           TRAFFIC_COUNT=60 \
           ./scripts/demo/capture_evidence.sh
       - name: Upload evidence artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-evidence-artifacts
           path: |

--- a/.github/workflows/kernel-compatibility-matrix.yml
+++ b/.github/workflows/kernel-compatibility-matrix.yml
@@ -17,7 +17,7 @@ jobs:
       count_6_8: ${{ steps.detect.outputs.count_6_8 }}
       reason: ${{ steps.detect.outputs.reason }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: detect
         env:
           RUNNER_STATUS_TOKEN: ${{ secrets.RUNNER_STATUS_TOKEN }}
@@ -36,7 +36,7 @@ jobs:
           echo "count_5_15=${count_5_15}" >> "$GITHUB_OUTPUT"
           echo "count_6_8=${count_6_8}" >> "$GITHUB_OUTPUT"
           echo "reason=${reason}" >> "$GITHUB_OUTPUT"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: kernel-compat-runner-discovery
           path: artifacts/compatibility/runner-discovery.json
@@ -46,8 +46,8 @@ jobs:
     if: needs.runner-discovery.outputs.count_5_15 != '0'
     runs-on: [self-hosted, linux, ebpf, kernel-5-15]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.23"
       - name: Probe compatibility profile
@@ -56,7 +56,7 @@ jobs:
         run: |
           mkdir -p artifacts/compatibility
           ./scripts/ci/kernel_compat_probe.sh --profile kernel-5-15 --out artifacts/compatibility/kernel-5-15.json
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: kernel-compat-kernel-5-15
           path: artifacts/compatibility/kernel-5-15.json
@@ -77,7 +77,7 @@ jobs:
             "timestamp_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           }
           EOF
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: kernel-compat-kernel-5-15
           path: artifacts/compatibility/kernel-5-15.json
@@ -87,8 +87,8 @@ jobs:
     if: needs.runner-discovery.outputs.count_6_8 != '0'
     runs-on: [self-hosted, linux, ebpf, kernel-6-8]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.23"
       - name: Probe compatibility profile
@@ -97,7 +97,7 @@ jobs:
         run: |
           mkdir -p artifacts/compatibility
           ./scripts/ci/kernel_compat_probe.sh --profile kernel-6-8 --out artifacts/compatibility/kernel-6-8.json
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: kernel-compat-kernel-6-8
           path: artifacts/compatibility/kernel-6-8.json
@@ -118,7 +118,7 @@ jobs:
             "timestamp_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           }
           EOF
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: kernel-compat-kernel-6-8
           path: artifacts/compatibility/kernel-6-8.json
@@ -132,8 +132,8 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
           pattern: kernel-compat-*
           merge-multiple: true
@@ -141,7 +141,7 @@ jobs:
       - name: Render compatibility report
         run: |
           RUN_ID="${{ github.run_id }}" ./scripts/ci/render_compatibility_report.sh artifacts/compatibility docs/compatibility.md
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: kernel-compatibility-report
           path: |

--- a/.github/workflows/nightly-ebpf-integration.yml
+++ b/.github/workflows/nightly-ebpf-integration.yml
@@ -19,7 +19,7 @@ jobs:
       has_ebpf_runner: ${{ steps.detect.outputs.has_ebpf_runner }}
       runner_count: ${{ steps.detect.outputs.runner_count }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: detect
         env:
           RUNNER_STATUS_TOKEN: ${{ secrets.RUNNER_STATUS_TOKEN }}
@@ -33,8 +33,8 @@ jobs:
     runs-on: [self-hosted, linux, ebpf]
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.23"
       - name: Build and unit tests
@@ -102,7 +102,7 @@ jobs:
           timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           EOF_MODE
       - name: Upload nightly artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nightly-ebpf-artifacts
           path: |
@@ -121,8 +121,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.23"
       - name: Build and unit tests
@@ -151,7 +151,7 @@ jobs:
           echo "::error::Fallback mode artifacts are marked release_grade=false and cannot be used for release claims."
           exit 1
       - name: Upload nightly artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nightly-ebpf-artifacts
           path: |

--- a/.github/workflows/pr-privileged-ebpf-smoke.yml
+++ b/.github/workflows/pr-privileged-ebpf-smoke.yml
@@ -18,7 +18,7 @@ jobs:
       reason: ${{ steps.detect.outputs.reason }}
       trusted_pr: ${{ steps.trust.outputs.trusted_pr }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: trust
         shell: bash
         run: |
@@ -47,8 +47,8 @@ jobs:
     runs-on: [self-hosted, linux, ebpf]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.23"
       - name: Build and unit tests
@@ -98,7 +98,7 @@ jobs:
           fi
       - name: Upload privileged smoke artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pr-privileged-smoke-artifacts
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,15 +19,15 @@ jobs:
     env:
       REGISTRY: ghcr.io
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.23"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Resolve image coordinates
         id: image
@@ -38,7 +38,7 @@ jobs:
           echo "rag_ref=${REGISTRY}/${owner_lc}/llm-slo-ebpf-toolkit-rag-service" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Build and push agent image
         id: build_agent_image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: cmd/agent/Dockerfile
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build and push rag-service image
         id: build_rag_image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: demo/rag-service/Dockerfile
@@ -118,7 +118,7 @@ jobs:
           PROV
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
         with:
           cosign-release: "v2.4.1"
 
@@ -130,14 +130,14 @@ jobs:
           cosign sign --yes "${{ steps.image.outputs.rag_ref }}@${{ steps.build_rag_image.outputs.digest }}"
 
       - name: Attest agent image provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-name: ${{ steps.image.outputs.agent_ref }}
           subject-digest: ${{ steps.build_agent_image.outputs.digest }}
           push-to-registry: true
 
       - name: Attest rag-service image provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-name: ${{ steps.image.outputs.rag_ref }}
           subject-digest: ${{ steps.build_rag_image.outputs.digest }}

--- a/.github/workflows/runner-canary.yml
+++ b/.github/workflows/runner-canary.yml
@@ -13,7 +13,7 @@ jobs:
   runner-canary:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Discover runner profiles
         env:
           RUNNER_STATUS_TOKEN: ${{ secrets.RUNNER_STATUS_TOKEN }}
@@ -50,7 +50,7 @@ jobs:
             echo "::error::runner-canary: kernel-6-8 profile unavailable."
             exit 1
           fi
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: runner-canary-${{ github.run_number }}
           path: artifacts/runner-canary/runner-discovery.json

--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -17,7 +17,7 @@ jobs:
   runner-health:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Discover self-hosted runner profiles
         env:
@@ -109,7 +109,7 @@ jobs:
 
       - name: Upload health artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: runner-health-${{ github.run_number }}
           path: artifacts/runner-health/runner-discovery.json

--- a/.github/workflows/v1-go-evaluator.yml
+++ b/.github/workflows/v1-go-evaluator.yml
@@ -33,7 +33,7 @@ jobs:
   evaluate-go:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Evaluate v1.0 GO criteria
         env:
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload GO evaluator artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: v1-go-evaluator-${{ github.run_number }}
           path: artifacts/release-go/

--- a/.github/workflows/weekly-benchmark.yml
+++ b/.github/workflows/weekly-benchmark.yml
@@ -19,7 +19,7 @@ jobs:
       has_ebpf_runner: ${{ steps.detect.outputs.has_ebpf_runner }}
       runner_count: ${{ steps.detect.outputs.runner_count }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: detect
         env:
           RUNNER_STATUS_TOKEN: ${{ secrets.RUNNER_STATUS_TOKEN }}
@@ -33,10 +33,10 @@ jobs:
     runs-on: [self-hosted, linux, ebpf]
     timeout-minutes: 240
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.23"
 
@@ -177,7 +177,7 @@ jobs:
         run: make m5-gate
 
       - name: Upload weekly artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: weekly-benchmark-${{ github.run_number }}
           path: artifacts/weekly-benchmark/
@@ -194,10 +194,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.23"
 
@@ -321,7 +321,7 @@ jobs:
         run: make m5-gate
 
       - name: Upload weekly artifacts (fallback)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: weekly-benchmark-fallback-${{ github.run_number }}
           path: artifacts/weekly-benchmark/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+version: "2"
 run:
   timeout: 5m
 linters:

--- a/cmd/attributor/main.go
+++ b/cmd/attributor/main.go
@@ -213,7 +213,12 @@ func writeAttributionsJSONL(path string, predictions []schema.IncidentAttributio
 	}()
 
 	buffered := bufio.NewWriter(writer)
-	defer buffered.Flush()
+	defer func() {
+		flushErr := buffered.Flush()
+		if err == nil && flushErr != nil {
+			err = flushErr
+		}
+	}()
 
 	encoder := json.NewEncoder(buffered)
 	for _, prediction := range predictions {

--- a/cmd/attributor/main.go
+++ b/cmd/attributor/main.go
@@ -258,7 +258,7 @@ func writeConfusionCSV(
 	if err != nil {
 		return fmt.Errorf("create confusion matrix file: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	matrix := attribution.BuildConfusionMatrix(samples, predictions)
 	keys := make([]attribution.MatrixKey, 0, len(matrix))

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -124,7 +124,7 @@ func loadInputSamples(path string) ([]collector.RawSample, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	return readSamples(file)
 }
 

--- a/cmd/correlationeval/main.go
+++ b/cmd/correlationeval/main.go
@@ -102,10 +102,9 @@ func writePredictionsCSV(path string, predictions []correlation.Prediction) erro
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	writer := csv.NewWriter(file)
-	defer writer.Flush()
 	if err := writer.Write([]string{
 		"case_id",
 		"signal",
@@ -131,6 +130,10 @@ func writePredictionsCSV(path string, predictions []correlation.Prediction) erro
 		}); err != nil {
 			return err
 		}
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/cmd/faultinject/main.go
+++ b/cmd/faultinject/main.go
@@ -55,7 +55,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "create output file failed: %v\n", err)
 		os.Exit(1)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	encoder := json.NewEncoder(file)
 	for _, sample := range samples {

--- a/cmd/faultreplay/main.go
+++ b/cmd/faultreplay/main.go
@@ -40,7 +40,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "create output file failed: %v\n", err)
 		os.Exit(1)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	encoder := json.NewEncoder(file)
 	for _, sample := range samples {

--- a/cmd/loadgen/main.go
+++ b/cmd/loadgen/main.go
@@ -54,7 +54,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "create output file failed: %v\n", err)
 		os.Exit(1)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	encoder := json.NewEncoder(file)
 	for i := 0; i < total; i++ {

--- a/demo/rag-service/main.go
+++ b/demo/rag-service/main.go
@@ -767,7 +767,7 @@ func loadCorpus(path string) ([]corpusDoc, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var docs []corpusDoc
 	if err := json.NewDecoder(f).Decode(&docs); err != nil {

--- a/demo/rag-service/main.go
+++ b/demo/rag-service/main.go
@@ -181,7 +181,7 @@ func (b llamaCPPBackend) Generate(ctx context.Context, prompt string, maxTokens 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("llama.cpp request failed with status %d", resp.StatusCode)
 	}

--- a/docs/releases/ops-status-2026-02-23.md
+++ b/docs/releases/ops-status-2026-02-23.md
@@ -269,3 +269,14 @@ Timestamp (UTC): 2026-02-23T21:00:00Z
 - 2026-04-06 scheduled window complete.
 - Dual-kernel truth (`5.15.x` + `6.8.x`) now aligns with runner profile labels and scheduled privileged CI evidence.
 - release-grade evidence = scheduled + privileged paths only; fallback artifacts remain non-release-grade.
+
+
+## Node24 Workflow Runtime Maintenance (2026-04-07)
+- Scope:
+  - GitHub Actions maintenance only; no product API/schema changes.
+  - Migrated workflow action versions to Node24-compatible releases in CI/release/nightly/weekly and related operational workflows.
+- Tracking:
+  - Implementation PR: https://github.com/ogulcanaydogan/LLM-SLO-eBPF-Toolkit/pull/27
+  - Related issue: https://github.com/ogulcanaydogan/LLM-SLO-eBPF-Toolkit/issues/26
+- Policy:
+  - release-grade evidence policy is unchanged: scheduled + privileged paths only.

--- a/pkg/attribution/io.go
+++ b/pkg/attribution/io.go
@@ -14,7 +14,7 @@ func LoadSamplesFromJSONL(path string) ([]FaultSample, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open samples file: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	samples := make([]FaultSample, 0)
 	scanner := bufio.NewScanner(file)

--- a/pkg/benchmark/harness.go
+++ b/pkg/benchmark/harness.go
@@ -300,7 +300,7 @@ func writeIncidentPredictions(
 	if err != nil {
 		return fmt.Errorf("create predictions csv: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	writer := csv.NewWriter(file)
 	defer writer.Flush()
@@ -356,7 +356,7 @@ func writeConfusionMatrix(path string, matrix map[attribution.MatrixKey]int) err
 	if err != nil {
 		return fmt.Errorf("create confusion matrix: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	writer := csv.NewWriter(file)
 	defer writer.Flush()
@@ -389,7 +389,7 @@ func writeCollectorOverhead(path string, rows []collectorOverheadRow) error {
 	if err != nil {
 		return fmt.Errorf("create collector overhead csv: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	writer := csv.NewWriter(file)
 	defer writer.Flush()

--- a/pkg/benchmark/harness_test.go
+++ b/pkg/benchmark/harness_test.go
@@ -1,8 +1,8 @@
 package benchmark
 
 import (
-	"encoding/json"
 	"encoding/csv"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -165,7 +165,7 @@ func readCSVRows(t *testing.T, path string) []string {
 	if err != nil {
 		t.Fatalf("open csv: %v", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	reader := csv.NewReader(file)
 	records, err := reader.ReadAll()

--- a/pkg/cdgate/gate.go
+++ b/pkg/cdgate/gate.go
@@ -89,7 +89,7 @@ func (q *HTTPQuerier) Query(ctx context.Context, query string) (float64, error) 
 	if err != nil {
 		return 0, fmt.Errorf("prometheus query: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/collector/kernel.go
+++ b/pkg/collector/kernel.go
@@ -33,7 +33,7 @@ func ProbeSmokeCheck() error {
 	if err != nil {
 		return fmt.Errorf("create smoke map: %w", err)
 	}
-	defer probeMap.Close()
+	defer func() { _ = probeMap.Close() }()
 
 	return nil
 }

--- a/pkg/collector/probe_manager.go
+++ b/pkg/collector/probe_manager.go
@@ -176,7 +176,9 @@ func (pm *ProbeManager) closeProbe(signal string, spec *ProbeSpec) {
 		}
 	}
 	if spec.RingBuf != nil {
-		spec.RingBuf.Close()
+		if err := spec.RingBuf.Close(); err != nil {
+			log.Printf("probe %s: ringbuf close error: %v", signal, err)
+		}
 	}
 	if spec.Collection != nil {
 		spec.Collection.Close()

--- a/pkg/collector/ringbuf.go
+++ b/pkg/collector/ringbuf.go
@@ -40,15 +40,15 @@ const (
 
 // bpfEvent matches the packed struct llm_slo_event from llm_slo_event.h.
 type bpfEvent struct {
-	PID          uint32
-	TID          uint32
-	TimestampNS  uint64
-	SignalType   uint32
-	ValueNS      uint64
-	ConnSrcPort  uint16
-	ConnDstPort  uint16
-	ConnDstIP    uint32
-	ErrnoVal     int32
+	PID         uint32
+	TID         uint32
+	TimestampNS uint64
+	SignalType  uint32
+	ValueNS     uint64
+	ConnSrcPort uint16
+	ConnDstPort uint16
+	ConnDstIP   uint32
+	ErrnoVal    int32
 }
 
 // RingBufConsumer reads llm_slo_event entries from eBPF ring buffers
@@ -105,7 +105,9 @@ func (c *RingBufConsumer) Start(ctx context.Context) {
 
 	<-ctx.Done()
 	for _, r := range readers {
-		r.Close()
+		if err := r.Close(); err != nil {
+			log.Printf("ringbuf close error: %v", err)
+		}
 	}
 	wg.Wait()
 	close(c.events)

--- a/pkg/correlation/evaluator.go
+++ b/pkg/correlation/evaluator.go
@@ -62,7 +62,7 @@ func LoadLabeledPairsFromJSONL(path string) ([]LabeledPair, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open labeled pairs file: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	out := make([]LabeledPair, 0)
 	scanner := bufio.NewScanner(file)

--- a/pkg/otel/probe_event_exporter.go
+++ b/pkg/otel/probe_event_exporter.go
@@ -68,7 +68,7 @@ func (e *ProbeEventExporter) ExportBatch(events []schema.ProbeEventV1) error {
 	if err != nil {
 		return fmt.Errorf("send otlp payload: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("otlp endpoint returned status %d", resp.StatusCode)

--- a/pkg/otel/probe_event_exporter_test.go
+++ b/pkg/otel/probe_event_exporter_test.go
@@ -13,7 +13,7 @@ import (
 func TestProbeEventExporterExportBatch(t *testing.T) {
 	var captured logsPayload
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer r.Body.Close()
+		defer func() { _ = r.Body.Close() }()
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
 			t.Fatalf("decode payload: %v", err)
 		}

--- a/pkg/otel/slo_event_exporter.go
+++ b/pkg/otel/slo_event_exporter.go
@@ -68,7 +68,7 @@ func (e *SLOEventExporter) ExportBatch(events []schema.SLOEvent) error {
 	if err != nil {
 		return fmt.Errorf("send otlp payload: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("otlp endpoint returned status %d", resp.StatusCode)

--- a/pkg/otel/slo_event_exporter_test.go
+++ b/pkg/otel/slo_event_exporter_test.go
@@ -13,7 +13,7 @@ import (
 func TestSLOEventExporterExportBatch(t *testing.T) {
 	var captured logsPayload
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer r.Body.Close()
+		defer func() { _ = r.Body.Close() }()
 		if r.Method != http.MethodPost {
 			t.Fatalf("expected POST, got %s", r.Method)
 		}

--- a/pkg/releasegate/gate.go
+++ b/pkg/releasegate/gate.go
@@ -626,7 +626,7 @@ func loadCollectorCPUSamples(path string) ([]collectorCPUSample, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open overhead file %s: %w", path, err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	reader := csv.NewReader(file)
 	records, err := reader.ReadAll()
@@ -686,7 +686,7 @@ func loadRawSamples(path string) ([]collector.RawSample, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open raw samples %s: %w", path, err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	scanner := bufio.NewScanner(file)
 	samples := make([]collector.RawSample, 0)

--- a/pkg/safety/overhead_guard.go
+++ b/pkg/safety/overhead_guard.go
@@ -134,7 +134,7 @@ func readTotalTicks() (uint64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("open /proc/stat: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	scanner := bufio.NewScanner(file)
 	if !scanner.Scan() {

--- a/pkg/webhook/exporter.go
+++ b/pkg/webhook/exporter.go
@@ -113,7 +113,7 @@ func (e *Exporter) doPost(payload []byte, contentType string) error {
 	if err != nil {
 		return fmt.Errorf("http post: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
 		return fmt.Errorf("drain response body: %w", err)
 	}


### PR DESCRIPTION
## Summary\n- upgrade GitHub Action versions to Node24-compatible releases across CI/release/scheduled workflows\n- keep scorecard SHA-pinned actions unchanged\n- no product API/schema changes\n\n## Changes\n- actions/checkout: v4 -> v6\n- actions/setup-go: v5 -> v6\n- golangci/golangci-lint-action: v6 -> v9\n- actions/upload-artifact: v4 -> v7\n- actions/download-artifact: v4 -> v8\n- docker/setup-buildx-action: v3 -> v4\n- docker/login-action: v3 -> v4\n- docker/build-push-action: v6 -> v7\n- sigstore/cosign-installer: v3 -> v4\n- actions/attest-build-provenance: v2 -> v4\n\n## Validation Plan\n- CI must be green on this branch\n- manual workflow_dispatch checks on branch:\n  - nightly-ebpf-integration\n  - weekly-benchmark\n  - kernel-compatibility-matrix\n  - e2e-evidence-report\n- verify fallback jobs are skipped on privileged path\n- verify Node20 deprecation annotations are gone from CI\n\nRefs #26