### PR TITLE
chore: skip privileged ebpf gate for dependabot prs

### DIFF
--- a/.github/workflows/pr-privileged-ebpf-smoke.yml
+++ b/.github/workflows/pr-privileged-ebpf-smoke.yml
@@ -26,6 +26,10 @@ jobs:
             echo "trusted_pr=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+            echo "trusted_pr=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [[ "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]]; then
             echo "trusted_pr=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary

- The `pr-privileged-ebpf-smoke.yml` trust step classifies Dependabot PRs as `trusted_pr=true` because they come from the same repo (`head.repo.full_name == github.repository`).
- When no self-hosted `[linux, ebpf]` runner is online, the `privileged-runner-required` job runs and explicitly exits 1. This job is part of the required `pr-gates` check, so both dependency-update PRs (#30, #31) are permanently BLOCKED.
- Dependabot bumps only update `go.mod`/`go.sum` or workflow action versions; they have no need for privileged runner access. The `fork-pr-no-privileged` SKIP path is the correct route for them.

## Change

Adds an early-exit to the trust step: if `github.actor == 'dependabot[bot]'`, set `trusted_pr=false` and exit before the repo-ownership check. This routes Dependabot PRs to `fork-pr-no-privileged` (prints a skip notice, exits 0) instead of `privileged-runner-required` (exits 1). Human contributors from the same repo are unaffected.

## Test plan

- [ ] After this PR merges, trigger `@dependabot rebase` on PRs #30 and #31.
- [ ] Verify `pr-gates` passes on those PRs (no longer fails on `privileged-runner-required`).
- [ ] Verify a manual PR from a same-repo branch still routes to `privileged-kind-smoke` when an eBPF runner is online, or `privileged-runner-required` when it is not.