### PR TITLE
feat: scaffold gpu memory bandwidth probe with nvml client stub

### DIFF
--- a/pkg/collector/gpu_bandwidth.go
+++ b/pkg/collector/gpu_bandwidth.go
@@ -1,0 +1,82 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ogulcanaydogan/llm-slo-ebpf-toolkit/pkg/nvml"
+)
+
+// GPUMetricSample holds a single GPU memory-bandwidth observation.
+// It is emitted by GPUBandwidthSampler on each collection tick and can
+// be forwarded to the attribution pipeline under fault-domain "gpu".
+type GPUMetricSample struct {
+	Timestamp        time.Time
+	DeviceIndex      int
+	BandwidthUtilPct float64
+	MemUsedBytes     uint64
+	MemTotalBytes    uint64
+}
+
+// FaultDomain returns the attribution domain label for GPU metrics.
+func (GPUMetricSample) FaultDomain() string { return "gpu" }
+
+// GPUBandwidthSampler polls NVIDIA GPU memory-bandwidth metrics via NVML
+// at a fixed interval and sends observations to the provided channel.
+//
+// Start returns nvml.ErrNotAvailable when no NVIDIA driver is present so
+// the caller can skip GPU probing on non-GPU hosts without crashing.
+type GPUBandwidthSampler struct {
+	interval time.Duration
+}
+
+// NewGPUBandwidthSampler creates a sampler with the given polling interval.
+func NewGPUBandwidthSampler(interval time.Duration) *GPUBandwidthSampler {
+	return &GPUBandwidthSampler{interval: interval}
+}
+
+// Start begins polling GPU memory-bandwidth metrics and sends samples to out.
+// Blocking; call in a goroutine. Stops when ctx is cancelled.
+// Returns nvml.ErrNotAvailable immediately when NVML is not present.
+func (s *GPUBandwidthSampler) Start(ctx context.Context, out chan<- GPUMetricSample) error {
+	if !nvml.Available() {
+		return fmt.Errorf("gpu_bandwidth sampler: %w", nvml.ErrNotAvailable)
+	}
+
+	count, err := nvml.DeviceCount()
+	if err != nil {
+		return fmt.Errorf("gpu_bandwidth sampler: device count: %w", err)
+	}
+	if count == 0 {
+		return fmt.Errorf("gpu_bandwidth sampler: no NVIDIA devices found")
+	}
+
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case t := <-ticker.C:
+			for i := range count {
+				info, err := nvml.QueryMemory(i)
+				if err != nil {
+					continue
+				}
+				select {
+				case out <- GPUMetricSample{
+					Timestamp:        t,
+					DeviceIndex:      i,
+					BandwidthUtilPct: info.BandwidthUtilPct,
+					MemUsedBytes:     info.UsedBytes,
+					MemTotalBytes:    info.TotalBytes,
+				}:
+				case <-ctx.Done():
+					return nil
+				}
+			}
+		}
+	}
+}

--- a/pkg/collector/gpu_bandwidth_test.go
+++ b/pkg/collector/gpu_bandwidth_test.go
@@ -1,0 +1,33 @@
+package collector_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ogulcanaydogan/llm-slo-ebpf-toolkit/pkg/collector"
+	"github.com/ogulcanaydogan/llm-slo-ebpf-toolkit/pkg/nvml"
+)
+
+func TestGPUMetricSampleFaultDomain(t *testing.T) {
+	s := collector.GPUMetricSample{}
+	if s.FaultDomain() != "gpu" {
+		t.Errorf("FaultDomain() = %q; want %q", s.FaultDomain(), "gpu")
+	}
+}
+
+func TestGPUBandwidthSamplerUnavailableOnNonGPUHost(t *testing.T) {
+	sampler := collector.NewGPUBandwidthSampler(100 * time.Millisecond)
+	out := make(chan collector.GPUMetricSample, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	err := sampler.Start(ctx, out)
+	if err == nil {
+		t.Skip("NVML available on this host; skipping unavailability test")
+	}
+	if !errors.Is(err, nvml.ErrNotAvailable) {
+		t.Errorf("Start error = %v; want to wrap nvml.ErrNotAvailable", err)
+	}
+}

--- a/pkg/nvml/client.go
+++ b/pkg/nvml/client.go
@@ -1,0 +1,62 @@
+// Package nvml wraps NVIDIA Management Library device queries.
+// On non-Linux hosts or hosts without an NVIDIA driver, all functions
+// return ErrNotAvailable so callers can skip GPU probes gracefully.
+package nvml
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+)
+
+// ErrNotAvailable is returned when NVML is not usable on the current host.
+var ErrNotAvailable = errors.New("nvml: not available on this host")
+
+// MemoryInfo holds instantaneous GPU memory metrics for a single device.
+type MemoryInfo struct {
+	// DeviceIndex is the NVML device ordinal (0-based).
+	DeviceIndex int
+	// UsedBytes is the amount of GPU memory currently allocated.
+	UsedBytes uint64
+	// TotalBytes is the total GPU memory capacity.
+	TotalBytes uint64
+	// BandwidthUtilPct is the memory-bandwidth utilisation percentage (0–100)
+	// as reported by nvmlDeviceGetMemoryInfo or derived from NVML perf counters.
+	BandwidthUtilPct float64
+}
+
+// Available reports whether NVML device queries can be made on this host.
+// It checks the OS (must be Linux) as a fast pre-filter; actual driver
+// availability is confirmed lazily by the first real NVML call.
+func Available() bool {
+	return runtime.GOOS == "linux"
+}
+
+// DeviceCount returns the number of NVIDIA GPU devices visible to NVML.
+//
+// Stub: real implementation calls nvml.Init() then nvml.DeviceGetCount().
+// Replace this body with go-nvml calls on GPU hosts:
+//
+//	import "github.com/NVIDIA/go-nvml/pkg/nvml"
+//	ret := nvml.Init(); if ret != nvml.SUCCESS { ... }
+//	count, ret := nvml.DeviceGetCount(); ...
+func DeviceCount() (int, error) {
+	if !Available() {
+		return 0, ErrNotAvailable
+	}
+	// Stub: no real NVML driver linked. Returns ErrNotAvailable even on Linux
+	// until the real go-nvml binding is wired in.
+	return 0, ErrNotAvailable
+}
+
+// QueryMemory returns memory metrics for the device at the given index.
+//
+// Stub: real implementation calls nvml.DeviceGetHandleByIndex then
+// nvml.DeviceGetMemoryInfo. Bandwidth utilisation requires a separate
+// nvml.DeviceGetFieldValues call on the NVML_FI_DEV_MEM_COPY_UTIL field.
+func QueryMemory(deviceIndex int) (MemoryInfo, error) {
+	if !Available() {
+		return MemoryInfo{}, ErrNotAvailable
+	}
+	return MemoryInfo{}, fmt.Errorf("device %d: %w", deviceIndex, ErrNotAvailable)
+}

--- a/pkg/nvml/client_test.go
+++ b/pkg/nvml/client_test.go
@@ -1,0 +1,38 @@
+package nvml_test
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+
+	"github.com/ogulcanaydogan/llm-slo-ebpf-toolkit/pkg/nvml"
+)
+
+func TestAvailableOnlyOnLinux(t *testing.T) {
+	got := nvml.Available()
+	want := runtime.GOOS == "linux"
+	if got != want {
+		t.Errorf("Available() = %v; want %v (GOOS=%s)", got, want, runtime.GOOS)
+	}
+}
+
+func TestDeviceCountReturnsErrNotAvailableOnNonGPUHost(t *testing.T) {
+	count, err := nvml.DeviceCount()
+	if err == nil {
+		// A real GPU host with go-nvml linked may succeed; skip in that case.
+		t.Skipf("nvml.DeviceCount succeeded with count=%d; skipping stub test on GPU host", count)
+	}
+	if !errors.Is(err, nvml.ErrNotAvailable) {
+		t.Errorf("DeviceCount error = %v; want to wrap nvml.ErrNotAvailable", err)
+	}
+}
+
+func TestQueryMemoryReturnsErrNotAvailableOnNonGPUHost(t *testing.T) {
+	_, err := nvml.QueryMemory(0)
+	if err == nil {
+		t.Skip("nvml.QueryMemory succeeded; skipping stub test on GPU host")
+	}
+	if !errors.Is(err, nvml.ErrNotAvailable) {
+		t.Errorf("QueryMemory error = %v; want to wrap nvml.ErrNotAvailable", err)
+	}
+}


### PR DESCRIPTION
- New `pkg/nvml` package: `Available()` (Linux gate), `DeviceCount()`, `QueryMemory()` — stubs return `ErrNotAvailable` on non-GPU hosts, making this CI-safe without an NVIDIA driver
- New `pkg/collector/GPUBandwidthSampler` polls NVML at a configurable interval and emits `GPUMetricSample` events under `fault-domain: "gpu"` for the Bayesian attribution pipeline
- Closes the v1.1.0 ROADMAP GPU bandwidth probe scaffold line; live `github.com/NVIDIA/go-nvml` wiring deferred to a follow-up PR that targets a GPU runner