### PR TITLE
chore: pin workflows to go 1.25 to clear pr-gates toolchain mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.25"
       - name: Go build
         run: go build ./...
       - name: Go test

--- a/.github/workflows/e2e-evidence-report.yml
+++ b/.github/workflows/e2e-evidence-report.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.25"
       - uses: docker/setup-buildx-action@v4
       - name: Build local demo images for kind
         run: |

--- a/.github/workflows/kernel-compatibility-matrix.yml
+++ b/.github/workflows/kernel-compatibility-matrix.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.25"
       - name: Probe compatibility profile
         env:
           STRICT: "true"
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.25"
       - name: Probe compatibility profile
         env:
           STRICT: "true"

--- a/.github/workflows/nightly-ebpf-integration.yml
+++ b/.github/workflows/nightly-ebpf-integration.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.25"
       - uses: docker/setup-buildx-action@v4
       - name: Build and unit tests
         run: |
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.25"
       - name: Build and unit tests
         run: |
           make build

--- a/.github/workflows/pr-privileged-ebpf-smoke.yml
+++ b/.github/workflows/pr-privileged-ebpf-smoke.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.25"
       - uses: docker/setup-buildx-action@v4
       - name: Build and unit tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.25"
 
       - uses: docker/setup-buildx-action@v4
 

--- a/.github/workflows/weekly-benchmark.yml
+++ b/.github/workflows/weekly-benchmark.yml
@@ -38,7 +38,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.25"
       - uses: docker/setup-buildx-action@v4
 
       - name: Build and validate
@@ -200,7 +200,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.25"
 
       - name: Build and validate
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed
+- All CI, release, nightly-integration, weekly-benchmark, kernel-compatibility, e2e-evidence, and pr-privileged-smoke workflows now pin `go-version: "1.25"` (was `"1.23"`); `go.mod` declares `go 1.25.0` and `GOTOOLCHAIN=local` was causing `pr-gates` to fail with "go.mod requires go >= 1.25.0" on every PR, including pending Dependabot rollups.
+
 ## v0.3.0 - 2026-02-20
 
 ### New eBPF Probes

--- a/roadmap.md
+++ b/roadmap.md
@@ -2,9 +2,9 @@
 
 ## v1.1.0 — Extended Kernel Probes (target: 2026-06-30)
 
-- Add GPU memory bandwidth probe via NVIDIA NVML integration alongside existing CPU/network probes
+- Add GPU memory bandwidth probe via NVIDIA NVML integration alongside existing CPU/network probes [scaffolded: `pkg/nvml/client.go` + `pkg/collector/gpu_bandwidth.go`; stubs return ErrNotAvailable on non-GPU hosts; real go-nvml wiring deferred]
 - CUDA kernel launch latency tracking for inference workloads on DGX Spark and A100 targets
-- New `fault-domain: gpu` classification in Bayesian attribution engine
+- New `fault-domain: gpu` classification in Bayesian attribution engine [GPUMetricSample.FaultDomain() = "gpu" wired]
 - `ebpf/probes/gpu_bandwidth.go` — new probe with CO-RE portability for kernel 5.15+
 
 ## v1.2.0 — Grafana Integration Pack (target: 2026-08-31)


### PR DESCRIPTION
- `go.mod` declares `go 1.25.0` but all 7 CI/release/benchmark/smoke workflows were still pinned to `go-version: "1.23"`; with `GOTOOLCHAIN=local` every build failed immediately with `go.mod requires go >= 1.25.0 (running go 1.23)`, causing `pr-gates` (required check) to fail on every open PR
- Fixes the root cause blocking Dependabot rollup PRs #35 and #36 from merging; after this lands both PRs will pick up a green `pr-gates` on rebase
- Also syncs `roadmap.md` GPU bandwidth probe scaffold notes that shipped in PR #34 but were missing from the main-branch ROADMAP