### PR TITLE
fix: don't hard-fail scheduled benchmark/evidence without eBPF runner

### DIFF
--- a/.github/workflows/e2e-evidence-report.yml
+++ b/.github/workflows/e2e-evidence-report.yml
@@ -88,9 +88,9 @@ jobs:
     if: needs.runner-preflight.outputs.has_ebpf_runner != 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Fail when no privileged runner is online
+      - name: Skip e2e evidence when no privileged runner is online
         run: |
-          echo "::error::No online self-hosted linux+ebpf runner available for e2e evidence workflow."
+          echo "::warning::No online self-hosted linux+ebpf runner; skipping e2e evidence capture (no release-grade evidence this cycle)."
           echo "runner_count=${{ needs.runner-preflight.outputs.runner_count }}"
           echo "reason=${{ needs.runner-preflight.outputs.reason }}"
-          exit 1
+          echo "Register a self-hosted linux+ebpf runner to generate release-grade e2e evidence."

--- a/.github/workflows/weekly-benchmark.yml
+++ b/.github/workflows/weekly-benchmark.yml
@@ -329,9 +329,8 @@ jobs:
           retention-days: 90
           if-no-files-found: warn
 
-      - name: Enforce release-grade benchmark path
+      - name: Note fallback benchmark mode
         if: github.event_name == 'schedule'
         run: |
-          echo "::error::Scheduled weekly benchmark requires privileged self-hosted eBPF runners."
-          echo "::error::Fallback mode artifacts are marked release_grade=false and cannot be used for release claims."
-          exit 1
+          echo "::warning::No privileged self-hosted eBPF runner online; produced synthetic fallback benchmark artifacts (release_grade=false)."
+          echo "::warning::Run on a self-hosted eBPF runner for release-grade evidence; fallback artifacts must not be used for release claims."


### PR DESCRIPTION
weekly-benchmark and e2e-evidence-report fired on schedule and exited 1 whenever no self-hosted eBPF runner was online, producing weekly red runs. Emit warnings and still publish (synthetic) artifacts instead of failing; release-grade evidence still requires a self-hosted runner (clearly marked).