### PR TITLE
chore(ci): add Node24 force flag to remaining workflows

### DIFF
--- a/.github/workflows/e2e-evidence-report.yml
+++ b/.github/workflows/e2e-evidence-report.yml
@@ -9,6 +9,9 @@ permissions:
   contents: read
   actions: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   runner-preflight:
     runs-on: ubuntu-latest

--- a/.github/workflows/kernel-compatibility-matrix.yml
+++ b/.github/workflows/kernel-compatibility-matrix.yml
@@ -9,6 +9,9 @@ permissions:
   contents: read
   actions: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   runner-discovery:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-privileged-ebpf-smoke.yml
+++ b/.github/workflows/pr-privileged-ebpf-smoke.yml
@@ -9,6 +9,9 @@ permissions:
   contents: read
   actions: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   runner-preflight:
     runs-on: ubuntu-latest

--- a/.github/workflows/runner-canary.yml
+++ b/.github/workflows/runner-canary.yml
@@ -8,6 +8,9 @@ permissions:
   contents: read
   actions: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   runner-canary:
     runs-on: ubuntu-latest

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,6 +9,9 @@ on:
 
 permissions: read-all
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   analysis:
     name: Scorecard Analysis


### PR DESCRIPTION
Closes #28.

Six workflows already set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` to suppress post-Node24 runtime/deprecation warnings. This adds the same top-level env var to the remaining five so all 11 workflows are consistent and warning-clean:

- e2e-evidence-report
- kernel-compatibility-matrix
- pr-privileged-ebpf-smoke
- runner-canary
- scorecard

No behavioural change — purely warning hygiene.