### PR TITLE
test(safety): cover overhead guard kill-switch branches

### DIFF
--- a/pkg/safety/overhead_guard_test.go
+++ b/pkg/safety/overhead_guard_test.go
@@ -1,0 +1,124 @@
+package safety
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+)
+
+// stubSampler returns a fixed sequence of CPU samples (or an error) so the
+// overhead guard can be exercised without reading real /proc counters.
+type stubSampler struct {
+	samples []CPUSample
+	err     error
+	calls   int
+}
+
+func (s *stubSampler) Sample() (CPUSample, error) {
+	if s.err != nil {
+		return CPUSample{}, s.err
+	}
+	out := s.samples[s.calls]
+	s.calls++
+	return out, nil
+}
+
+func TestOverheadGuardNilSamplerReturnsError(t *testing.T) {
+	g := NewOverheadGuardWithSampler(5.0, nil)
+	_, trip, err := g.Evaluate()
+	if err == nil {
+		t.Fatal("expected error for nil sampler, got nil")
+	}
+	if trip {
+		t.Error("nil sampler must not trip the guard")
+	}
+}
+
+func TestOverheadGuardPropagatesSamplerError(t *testing.T) {
+	sentinel := errors.New("sample failed")
+	g := NewOverheadGuardWithSampler(5.0, &stubSampler{err: sentinel})
+	if _, _, err := g.Evaluate(); !errors.Is(err, sentinel) {
+		t.Fatalf("expected sampler error to propagate, got %v", err)
+	}
+}
+
+func TestOverheadGuardFirstCallEstablishesBaseline(t *testing.T) {
+	g := NewOverheadGuardWithSampler(5.0, &stubSampler{
+		samples: []CPUSample{{ProcessTicks: 10, TotalTicks: 100}},
+	})
+	pct, trip, err := g.Evaluate()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pct != 0 || trip {
+		t.Errorf("first call should be a no-op baseline, got pct=%v trip=%v", pct, trip)
+	}
+}
+
+func TestOverheadGuardTripsWhenOverThreshold(t *testing.T) {
+	g := NewOverheadGuardWithSampler(5.0, &stubSampler{
+		samples: []CPUSample{
+			{ProcessTicks: 0, TotalTicks: 0},
+			{ProcessTicks: 100, TotalTicks: 100},
+		},
+	})
+	if _, _, err := g.Evaluate(); err != nil {
+		t.Fatalf("baseline error: %v", err)
+	}
+
+	pct, trip, err := g.Evaluate()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// ratio 1.0 * 100 * NumCPU; independent of the host CPU count beyond scaling.
+	want := 100.0 * float64(runtime.NumCPU())
+	if pct != want {
+		t.Errorf("expected pct=%v, got %v", want, pct)
+	}
+	if !trip {
+		t.Error("expected guard to trip when overhead exceeds the max percentage")
+	}
+}
+
+func TestOverheadGuardStaysUnderThreshold(t *testing.T) {
+	g := NewOverheadGuardWithSampler(50.0, &stubSampler{
+		samples: []CPUSample{
+			{ProcessTicks: 5, TotalTicks: 100},
+			{ProcessTicks: 5, TotalTicks: 200}, // host advanced, process did not
+		},
+	})
+	if _, _, err := g.Evaluate(); err != nil {
+		t.Fatalf("baseline error: %v", err)
+	}
+
+	pct, trip, err := g.Evaluate()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pct != 0 {
+		t.Errorf("expected 0%% overhead when the process did no work, got %v", pct)
+	}
+	if trip {
+		t.Error("guard must not trip below the max percentage")
+	}
+}
+
+func TestOverheadGuardIgnoresNonIncreasingTotalTicks(t *testing.T) {
+	g := NewOverheadGuardWithSampler(5.0, &stubSampler{
+		samples: []CPUSample{
+			{ProcessTicks: 10, TotalTicks: 200},
+			{ProcessTicks: 50, TotalTicks: 150}, // total counter went backwards
+		},
+	})
+	if _, _, err := g.Evaluate(); err != nil {
+		t.Fatalf("baseline error: %v", err)
+	}
+
+	pct, trip, err := g.Evaluate()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pct != 0 || trip {
+		t.Errorf("non-increasing total ticks must yield 0/false, got pct=%v trip=%v", pct, trip)
+	}
+}


### PR DESCRIPTION
## What
`pkg/safety/overhead_guard.go` is the CPU **kill-switch** that disables eBPF sampling when the agent's own overhead grows too large. Its decision branches were thinly covered. This adds focused, fully offline unit tests for `OverheadGuard.Evaluate`, driving it through an injected `CPUSampler` stub (no `/proc`, no Linux needed):

- nil sampler → error, no trip
- sampler error propagation
- first-call baseline no-op
- **trips** when measured overhead exceeds the max percentage (asserts the `NumCPU`-scaled percentage)
- stays below threshold when the process did no work
- ignores non-increasing total CPU ticks (counter reset / host rollover)

## Why
The kill-switch protects the host from a runaway eBPF agent; its threshold and counter-handling logic is exactly where a silent regression would either fail to disengage (overhead unbounded) or trip spuriously. The tests use the existing `NewOverheadGuardWithSampler` injection seam, so they are deterministic and run on any OS. The Linux-only `/proc` readers remain exercised in CI's Linux runners.

## Verification
`go test ./pkg/safety/...` → pass, `pkg/safety` coverage 35.0% → 38.8% (the remainder is Linux-only `/proc` I/O). `gofmt`, `go vet`, `golangci-lint run` all clean.