### PR TITLE
fix: scorecard job-level env

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,13 +9,12 @@ on:
 
 permissions: read-all
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   analysis:
     name: Scorecard Analysis
     runs-on: ubuntu-24.04
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     permissions:
       security-events: write
       id-token: write


### PR DESCRIPTION
Scorecard action forbids workflow-level env; moved FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 to the job. (Scorecard runs on main, so this verifies after merge.)