### PR TITLE
docs: add issue templates and SLO-gate workflow example

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Report a problem with the toolkit (agent, collector, attributor, sloctl, charts)
+title: "[bug] "
+labels: bug
+---
+
+## What happened
+
+A clear description of the bug.
+
+## Expected behavior
+
+What you expected to happen instead.
+
+## Reproduction
+
+Steps to reproduce, including the exact command(s) and flags:
+
+```bash
+# e.g. go run ./cmd/sloctl cdgate check --prometheus-url ...
+```
+
+## Environment
+
+- Toolkit version / commit:
+- Component (agent / collector / attributor / sloctl / Helm chart):
+- Kubernetes version (if applicable):
+- Kernel version (if the eBPF agent is involved): `uname -r`
+- OS / arch:
+
+## Logs and output
+
+```
+paste relevant logs, error output, or attribution JSON here
+```
+
+## Additional context
+
+Anything else that helps narrow it down.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security report
+    url: https://github.com/ogulcanaydogan/LLM-SLO-eBPF-Toolkit/security/policy
+    about: Please report security vulnerabilities privately, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest a new signal, attribution, exporter, or usability improvement
+title: "[feature] "
+labels: enhancement
+---
+
+## Problem
+
+What gap or pain point are you trying to address? What can't you do today?
+
+## Proposed solution
+
+What you would like the toolkit to do. Be specific about the component
+(agent / collector / attributor / sloctl / Helm chart / exporter).
+
+## Alternatives considered
+
+Other approaches you have thought about or currently work around.
+
+## Additional context
+
+Links, references, or examples (e.g. a kernel signal, an SLO definition, a
+webhook target) that help scope the work.

--- a/README.md
+++ b/README.md
@@ -454,6 +454,10 @@ go run ./cmd/sloctl cdgate check \
 # --fail-open (default: true) passes the gate if Prometheus is unreachable
 ```
 
+A ready-to-copy GitHub Actions workflow is provided at
+[`examples/cicd/slo-gate.yml`](examples/cicd/slo-gate.yml) — drop it into your
+service repo and set `PROMETHEUS_URL` to gate deploys on SLO health.
+
 ### Agent and Collector
 ```bash
 # Run agent with OTLP export

--- a/examples/cicd/slo-gate.yml
+++ b/examples/cicd/slo-gate.yml
@@ -1,0 +1,43 @@
+# Example: gate a deployment on LLM SLO health using sloctl.
+#
+# Copy this file into YOUR service repository at
+# .github/workflows/slo-gate.yml and adjust the thresholds and the
+# Prometheus URL to match your environment. It is intentionally NOT placed
+# under .github/workflows/ in this toolkit repo, because it depends on a
+# reachable Prometheus that only exists in a real deployment.
+#
+# What it does: before promoting a release, it queries your Prometheus for the
+# LLM SLO signals (TTFT p95, error rate, error-budget burn rate) and fails the
+# job — blocking the deploy — when any threshold is breached.
+
+name: SLO Gate
+
+on:
+  workflow_dispatch: {}
+  # Typical real usage: run as a required check before a deploy job, e.g.
+  # deploy:
+  #   needs: [slo-gate]
+
+jobs:
+  slo-gate:
+    name: Check LLM SLOs before deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install sloctl
+        run: go install github.com/ogulcanaydogan/llm-slo-ebpf-toolkit/cmd/sloctl@latest
+
+      - name: Gate on SLO health
+        env:
+          # Prefer a repo/environment secret or variable over a hardcoded URL.
+          PROMETHEUS_URL: ${{ secrets.PROMETHEUS_URL || vars.PROMETHEUS_URL }}
+        run: |
+          sloctl cdgate check \
+            --prometheus-url "$PROMETHEUS_URL" \
+            --ttft-p95-ms 800 \
+            --error-rate 0.05 \
+            --burn-rate 2.0 \
+            --output json
+          # Exit 0 = SLOs healthy (deploy may proceed)
+          # Exit 1 = SLO breach (this job fails and blocks the deploy)
+          # Add --fail-open=false to FAIL when Prometheus is unreachable
+          # (default is fail-open: an unreachable Prometheus passes the gate).


### PR DESCRIPTION
## What
- Adds `.github/ISSUE_TEMPLATE/` (bug report, feature request, config) so new issues are structured.
- Adds a copy-pasteable CI example `examples/cicd/slo-gate.yml` that installs `sloctl` and gates a deploy on LLM SLO health, and links it from the README CD-gate section.

## Why
The repo had no issue templates and no ready-to-use workflow file for the CD gate — the README documented the `sloctl cdgate check` command but a first-time adopter had to assemble the workflow themselves. These lower the barrier to filing good issues and to actually wiring the gate into a pipeline.

## How
- The example lives under `examples/cicd/` (not `.github/workflows/`) on purpose, so it does not execute in this repo (it needs a reachable Prometheus); it is documented as a template to copy into a service repo.
- It uses the real `sloctl cdgate check` invocation from the README. Doc/scaffolding only; no code touched.