### PR TITLE
test: cover Bayesian attribution routing and accuracy fallbacks

### DIFF
--- a/pkg/attribution/pipeline_test.go
+++ b/pkg/attribution/pipeline_test.go
@@ -173,3 +173,131 @@ func TestCoverageAccuracyThresholdFilters(t *testing.T) {
 		t.Fatalf("expected 0.5 coverage accuracy with threshold, got %f", ca)
 	}
 }
+
+func TestBuildAttributionsBayesNilAttributor(t *testing.T) {
+	samples := []FaultSample{
+		{FaultLabel: "dns_latency"},
+		{FaultLabel: "cpu_throttle"},
+	}
+
+	out := BuildAttributionsBayes(samples, nil)
+	if len(out) != len(samples) {
+		t.Fatalf("expected %d attributions, got %d", len(samples), len(out))
+	}
+}
+
+func TestBuildAttributionsBayesWithSignalsPopulatesHypotheses(t *testing.T) {
+	attributor := NewBayesianAttributor()
+	samples := []FaultSample{
+		{
+			IncidentID: "inc-1",
+			FaultLabel: "dns_latency",
+			Signals: map[string]float64{
+				"dns_latency_ms":        120, // above the elevated threshold (40)
+				"tcp_retransmits_total": 5,   // above the elevated threshold (2)
+			},
+		},
+	}
+
+	out := BuildAttributionsBayes(samples, attributor)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 attribution, got %d", len(out))
+	}
+	if out[0].PredictedFaultDomain == "" {
+		t.Fatal("expected a predicted fault domain, got empty")
+	}
+	if len(out[0].FaultHypotheses) == 0 {
+		t.Fatal("expected fault hypotheses when signals are elevated, got none")
+	}
+}
+
+func TestBuildAttributionsRoutesUnknownModesToBayes(t *testing.T) {
+	samples := []FaultSample{
+		{FaultLabel: "dns_latency", Signals: map[string]float64{"dns_latency_ms": 120}},
+	}
+
+	// Empty, garbage, and explicit "bayes" (any casing) all take the Bayesian
+	// path, which populates hypotheses; the rule path never does.
+	for _, mode := range []string{"bayes", "BAYES", " bayes ", "", "garbage"} {
+		out := BuildAttributions(samples, mode)
+		if len(out) != 1 {
+			t.Fatalf("mode %q: expected 1 attribution, got %d", mode, len(out))
+		}
+		if len(out[0].FaultHypotheses) == 0 {
+			t.Fatalf("mode %q: expected the Bayesian path (hypotheses populated)", mode)
+		}
+	}
+}
+
+func TestNormalizeAttributionMode(t *testing.T) {
+	cases := map[string]string{
+		"rule":    AttributionModeRule,
+		"RULE":    AttributionModeRule,
+		"  rule ": AttributionModeRule,
+		"bayes":   AttributionModeBayes,
+		"BAYES":   AttributionModeBayes,
+		"":        AttributionModeBayes,
+		"unknown": AttributionModeBayes,
+	}
+
+	for in, want := range cases {
+		if got := normalizeAttributionMode(in); got != want {
+			t.Fatalf("normalizeAttributionMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestPartialAccuracyFallsBackToFaultLabel(t *testing.T) {
+	// No ExpectedDomains and no ExpectedDomain: fall back to MapFaultLabel.
+	samples := []FaultSample{
+		{FaultLabel: "dns_latency"},  // -> network_dns
+		{FaultLabel: "cpu_throttle"}, // -> cpu_throttle
+	}
+	predictions := []schema.IncidentAttribution{
+		{PredictedFaultDomain: "network_dns"},     // matches mapped label
+		{PredictedFaultDomain: "memory_pressure"}, // does not match
+	}
+
+	if pa := PartialAccuracy(samples, predictions); pa != 0.5 {
+		t.Fatalf("expected 0.5 partial accuracy via fault-label fallback, got %f", pa)
+	}
+}
+
+func TestPartialAccuracyFallsBackToExpectedDomain(t *testing.T) {
+	// No ExpectedDomains but ExpectedDomain is set directly.
+	samples := []FaultSample{
+		{ExpectedDomain: "provider_throttle"},
+	}
+	predictions := []schema.IncidentAttribution{
+		{PredictedFaultDomain: "provider_throttle"},
+	}
+
+	if pa := PartialAccuracy(samples, predictions); pa != 1.0 {
+		t.Fatalf("expected 1.0 partial accuracy via expected-domain fallback, got %f", pa)
+	}
+}
+
+func TestPartialAccuracyEmptyPredictions(t *testing.T) {
+	if pa := PartialAccuracy([]FaultSample{{FaultLabel: "dns_latency"}}, nil); pa != 0 {
+		t.Fatalf("expected 0 partial accuracy for empty predictions, got %f", pa)
+	}
+}
+
+func TestCoverageAccuracyFallsBackToFaultLabel(t *testing.T) {
+	samples := []FaultSample{
+		{FaultLabel: "dns_latency"}, // -> network_dns
+	}
+	predictions := []schema.IncidentAttribution{
+		{PredictedFaultDomain: "network_dns"},
+	}
+
+	if ca := CoverageAccuracy(samples, predictions, 0.1); ca != 1.0 {
+		t.Fatalf("expected 1.0 coverage accuracy via fault-label fallback, got %f", ca)
+	}
+}
+
+func TestCoverageAccuracyEmptyPredictions(t *testing.T) {
+	if ca := CoverageAccuracy([]FaultSample{{FaultLabel: "dns_latency"}}, nil, 0.1); ca != 0 {
+		t.Fatalf("expected 0 coverage accuracy for empty predictions, got %f", ca)
+	}
+}


### PR DESCRIPTION
## What
Raises `pkg/attribution` coverage from 79.6% to 90.1% by testing previously-uncovered, cross-platform statistical-attribution logic in `pipeline.go`.

## Why
`BuildAttributionsBayes` (the Bayesian multi-fault entry point) had **0% coverage**, and the mode routing plus the accuracy-metric fallback branches were only partially exercised. These are pure, deterministic functions on the core attribution path.

## How
White-box tests (stdlib `testing`, no testify, matching the package style) covering:
- `BuildAttributionsBayes` with a nil attributor (default priors) and with elevated signals (asserts hypotheses populated).
- `BuildAttributions` / `normalizeAttributionMode` routing for `bayes`, empty, and unknown modes (all fall back to the Bayesian path).
- `PartialAccuracy` / `CoverageAccuracy` `ExpectedDomains == nil` fallbacks (via `ExpectedDomain` and via `MapFaultLabel(FaultLabel)`) and the empty-predictions guard.

Per-function: `BuildAttributionsBayes` 0→100%, `BuildAttributions` 66.7→100%, `normalizeAttributionMode` 50→100%, `PartialAccuracy` →94%, `CoverageAccuracy` →93%.

## Verification
Fully offline/darwin-runnable. `go test ./pkg/attribution/` passes (90.1%), `gofmt`, `go vet`, and `golangci-lint` all clean. No production code changed.