### PR TITLE
fix: drop job env so Scorecard can publish results

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,8 +13,6 @@ jobs:
   analysis:
     name: Scorecard Analysis
     runs-on: ubuntu-24.04
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     permissions:
       security-events: write
       id-token: write


### PR DESCRIPTION
## Problem
The **OpenSSF Scorecard** workflow has failed on every push to `main` since late June. The analysis actually runs (score 5.4), but the publish step is rejected:

```
error sending scorecard results to webapp: http response 400,
"workflow verification failed: scorecard job contains env vars,
 see https://github.com/ossf/scorecard-action#workflow-restrictions"
```

`ossf/scorecard-action` enforces a workflow restriction when `publish_results: true`: the scorecard job must not define `env` vars (anti-tampering guard on the results it signs and publishes to the OpenSSF API). The job carried a leftover `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"`, tripping that check.

## Fix
Remove the job-level `env` block. The pinned JS actions run on their declared runtime without it (a deprecation warning at most, not a failure), and the job now matches the other 5 portfolio repos whose Scorecard workflow publishes cleanly (verified: none of them define a job-level env, all use `publish_results: true`, all green).

Workflow-only change; the `ci` workflow was already green.